### PR TITLE
CoC on singleton and bind for reduced verbosity

### DIFF
--- a/src/tad/DI52/Container.php
+++ b/src/tad/DI52/Container.php
@@ -698,7 +698,11 @@ class tad_DI52_Container implements ArrayAccess {
 	 * @param array $afterBuildMethods An array of methods that should be called on the built implementation after
 	 *                                  resolving it.
 	 */
-	public function bind($classOrInterface, $implementation, array $afterBuildMethods = null) {
+	public function bind($classOrInterface, $implementation = null, array $afterBuildMethods = null) {
+		if (is_null($implementation)) {
+			$implementation = $classOrInterface;
+		}
+		
 		$this->offsetUnset($classOrInterface);
 
 		$this->bindings[$classOrInterface] = $classOrInterface;
@@ -729,7 +733,11 @@ class tad_DI52_Container implements ArrayAccess {
 	 * @param array $afterBuildMethods An array of methods that should be called on the built implementation after
 	 *                                  resolving it.
 	 */
-	public function singleton($classOrInterface, $implementation, array $afterBuildMethods = null) {
+	public function singleton($classOrInterface, $implementation = null, array $afterBuildMethods = null) {
+		if (is_null($implementation)) {
+			$implementation = $classOrInterface;
+		}
+			
 		$this->bind($classOrInterface, $implementation, $afterBuildMethods);
 
 		$this->singletons[$classOrInterface] = $classOrInterface;


### PR DESCRIPTION
This suggestion aims to reduce verbosity by following a Convention over Configuration philosophy.

If the class you are binding is the same as the return, it allows you to omit the second parameter of `bind` and `singleton`:

```php
// I want Foo::class to be a singleton.
$container->singleton('Foo::class');

// Same as
$container->singleton('Foo::class', 'Foo::class');
```

PS: I have not tested this PR, I'm opening this from GitHub web editor