### PR TITLE
Allow to bind instantiable classes with one parameter

### DIFF
--- a/src/tad/DI52/Container.php
+++ b/src/tad/DI52/Container.php
@@ -697,8 +697,19 @@ class tad_DI52_Container implements ArrayAccess {
 	 *                                  an object or a closure.
 	 * @param array $afterBuildMethods An array of methods that should be called on the built implementation after
 	 *                                  resolving it.
+	 *
+	 * @throws ReflectionException      When given a class name that does not exist.
+	 * @throws InvalidArgumentException When given a class name that can not be instantiated.
 	 */
-	public function bind($classOrInterface, $implementation, array $afterBuildMethods = null) {
+	public function bind($classOrInterface, $implementation = null, array $afterBuildMethods = null) {
+		if (is_null($implementation)) {
+			$reflection = new ReflectionClass($classOrInterface);
+			if (!$reflection->isInstantiable()) {
+				throw new InvalidArgumentException( sprintf('To bind a class in the Container without defining an implementation, the class must be instantiable. %s is not instantiable.', $classOrInterface) );
+			}
+			$implementation = $classOrInterface;
+		}
+
 		$this->offsetUnset($classOrInterface);
 
 		$this->bindings[$classOrInterface] = $classOrInterface;
@@ -729,7 +740,7 @@ class tad_DI52_Container implements ArrayAccess {
 	 * @param array $afterBuildMethods An array of methods that should be called on the built implementation after
 	 *                                  resolving it.
 	 */
-	public function singleton($classOrInterface, $implementation, array $afterBuildMethods = null) {
+	public function singleton($classOrInterface, $implementation = null, array $afterBuildMethods = null) {
 		$this->bind($classOrInterface, $implementation, $afterBuildMethods);
 
 		$this->singletons[$classOrInterface] = $classOrInterface;

--- a/src/tad/DI52/Container.php
+++ b/src/tad/DI52/Container.php
@@ -698,8 +698,8 @@ class tad_DI52_Container implements ArrayAccess {
 	 * @param array $afterBuildMethods An array of methods that should be called on the built implementation after
 	 *                                  resolving it.
 	 *
-	 * @throws ReflectionException      When given a class name that does not exist.
-	 * @throws InvalidArgumentException When given a class name that can not be instantiated.
+	 * @throws ReflectionException      When binding a class that does not exist without defining an implementation.
+	 * @throws InvalidArgumentException When binding a class that cannot be instantiated without defining an implementation.
 	 */
 	public function bind($classOrInterface, $implementation = null, array $afterBuildMethods = null) {
 		if (is_null($implementation)) {

--- a/tests/53-above/Container53CompatTest.php
+++ b/tests/53-above/Container53CompatTest.php
@@ -742,4 +742,70 @@ class Container53CompatTest extends \PHPUnit_Framework_TestCase
 
 		$this->assertInstanceOf('Acme\ClassOne', $callback());
 	}
+
+	/**
+	 * @test
+	 * it should allow to bind with one parameter
+	 */
+	public function it_should_allow_to_bind_with_one_parameter() {
+		$container = new tad_DI52_Container();
+
+		$container->bind(ClassFourteen::class);
+
+		$instance = $container->make(ClassFourteen::class);
+
+		$this->assertInstanceOf(ClassFourteen::class, $instance);
+	}
+
+	/**
+	 * @test
+	 * it should allow to bind singleton with one parameter
+	 */
+	public function it_should_allow_to_bind_singleton_with_one_parameter() {
+		$container = new tad_DI52_Container();
+
+		$container->singleton(ClassFourteen::class);
+
+		$instance1 = $container->make(ClassFourteen::class);
+		$instance2 = $container->make(ClassFourteen::class);
+
+		$this->assertInstanceOf(ClassFourteen::class, $instance1);
+		$this->assertEquals($instance1, $instance2);
+	}
+
+	/** @test */
+	public function it_should_throw_if_binding_string_with_one_parameter() {
+		$this->setExpectedException(ReflectionException::class);
+
+		$container = new tad_DI52_Container();
+
+		$container->bind('not-a-class');
+	}
+
+	/** @test */
+	public function it_should_throw_if_binding_interface_with_one_parameter() {
+		$this->setExpectedException(InvalidArgumentException::class);
+
+		$container = new tad_DI52_Container();
+
+		$container->bind(One::class);
+	}
+
+	/** @test */
+	public function it_should_throw_if_binding_abstract_with_one_parameter() {
+		$this->setExpectedException(InvalidArgumentException::class);
+
+		$container = new tad_DI52_Container();
+
+		$container->bind(AbstractClass::class);
+	}
+
+	/** @test */
+	public function it_should_throw_if_binding_private_constructor_with_one_parameter() {
+		$this->setExpectedException(InvalidArgumentException::class);
+
+		$container = new tad_DI52_Container();
+
+		$container->bind(PrivateConstructor::class);
+	}
 }

--- a/tests/data/test-classes.php
+++ b/tests/data/test-classes.php
@@ -427,3 +427,9 @@ class Depending {
 		return $this->dependency;
 	}
 }
+
+abstract class AbstractClass {};
+
+class PrivateConstructor {
+	private function __construct() {}
+}


### PR DESCRIPTION
As discussed on https://github.com/lucatume/di52/pull/10

It allows to bind classes that can be instantiated with a single parameter.

A class that is instantiable is a concrete class (not abstract, interface, or traits) with a public constructor. Concrete classes that implement interfaces or extend from abstracts are instantiable.

For more details, see https://www.php.net/manual/en/reflectionclass.isinstantiable.php