### PR TITLE
Reuse callbacks as they essentially return the same thing

### DIFF
--- a/src/tad/DI52/Container.php
+++ b/src/tad/DI52/Container.php
@@ -763,6 +763,16 @@ class tad_DI52_Container implements ArrayAccess {
 			throw new RuntimeException('Callback method must be a string');
 		}
 
+		$classOrInterfaceName = $classOrInterface;
+
+		if (is_object($classOrInterface)) {
+			// Set the name based on the class name.
+			$classOrInterfaceName = get_class($classOrInterface);
+		} elseif (isset($this->callbacks[$classOrInterfaceName . '::' . $method])) {
+			// Only return the existing callback if $classOrInterface was not an object (so it remains unique).
+			return $this->callbacks[$classOrInterfaceName . '::' . $method];
+		}
+
 		if ($this->useClosures) {
 			$f = di52_callbackClosure($this, $classOrInterface, $method);
 		} else {
@@ -791,7 +801,7 @@ class tad_DI52_Container implements ArrayAccess {
 			$classOrInterface = get_class($classOrInterface);
 		}
 
-		$this->callbacks[$classOrInterface . '::' . $method] = $f;
+		$this->callbacks[$classOrInterfaceName . '::' . $method] = $f;
 
 		return $f;
 	}


### PR DESCRIPTION
If the class or interface passed in is an object, it has special handling already to ensure it's unique. Otherwise it will return as the same callback ultimately.

https://github.com/lucatume/di52/blob/dd12c213578f8fc503c79ff2689de9aa8167d9f1/src/tad/DI52/closuresSupport.php#L14