### PR TITLE
PHP 8+ compatibility

### DIFF
--- a/src/tad/DI52/Container.php
+++ b/src/tad/DI52/Container.php
@@ -805,7 +805,11 @@ class tad_DI52_Container implements ArrayAccess {
 	}
 
 	public function _getParameter(ReflectionParameter $parameter) {
-		$class = $parameter->getClass();
+		if (defined( 'PHP_VERSION_ID' ) && PHP_VERSION_ID >= 80000) {
+			$class = $parameter->getType() && ! $parameter->getType()->isBuiltin() ? new ReflectionClass( $parameter->getType()->getName() ) : null;
+		} else {
+			$class = $parameter->getClass();
+		}
 
 		if (null === $class) {
 			if (!$parameter->isDefaultValueAvailable()) {
@@ -814,9 +818,13 @@ class tad_DI52_Container implements ArrayAccess {
 			return $parameter->getDefaultValue();
 		}
 
-		$parameterClass = $parameter->getClass()->getName();
+		if (defined( 'PHP_VERSION_ID' ) && PHP_VERSION_ID >= 80000) {
+			$parameterClass = $parameter->getType() && ! $parameter->getType()->isBuiltin() ? $parameter->getType()->getName() : null;
+		} else {
+			$parameterClass = $parameter->getClass()->getName();
+		}
 
-		if (!$this->isBound($parameterClass) && !$parameter->getClass()->isInstantiable()) {
+		if (!$this->isBound($parameterClass) && !$class->isInstantiable()) {
 			if (!$parameter->isDefaultValueAvailable()) {
 				throw new ReflectionException("parameter '{$parameter->name}' of '{$this->resolving}::__construct' does not have a default value.");
 			}


### PR DESCRIPTION
On PHP 8 usage of `getClass` for the `ReflectionParameter` will throw a deprecation warning.

https://php.watch/versions/8.0/deprecated-reflectionparameter-methods#getClass

Currently, it was triggering a couple of problems on our implementation for Common, I didn't implement any tests for these yet. I wonder how we would do that specifically with TravisCI tests and PHP 8. 

_It did fix the problems on The Events Calendar._