### PR TITLE
Fix contextual binding failing if interface has not been bound at least once before

### DIFF
--- a/src/tad/DI52/Container.php
+++ b/src/tad/DI52/Container.php
@@ -816,7 +816,7 @@ class tad_DI52_Container implements ArrayAccess {
 
 		$parameterClass = $parameter->getClass()->getName();
 
-		if (!$this->isBound($parameterClass) && !$parameter->getClass()->isInstantiable()) {
+        if (!$this->isBound($parameterClass) && !$parameter->getClass()->isInstantiable() && !isset($this->contexts[$parameterClass])) {
 			if (!$parameter->isDefaultValueAvailable()) {
 				throw new ReflectionException("parameter '{$parameter->name}' of '{$this->resolving}::__construct' does not have a default value.");
 			}

--- a/src/tad/DI52/Container.php
+++ b/src/tad/DI52/Container.php
@@ -824,7 +824,7 @@ class tad_DI52_Container implements ArrayAccess {
 			$parameterClass = $parameter->getClass()->getName();
 		}
 
-        if (!$this->isBound($parameterClass) && !$class->isInstantiable() && !isset($this->contexts[$parameterClass])) {
+		if (!$this->isBound($parameterClass) && !$class->isInstantiable() && !isset($this->contexts[$parameterClass])) {
 			if (!$parameter->isDefaultValueAvailable()) {
 				throw new ReflectionException("parameter '{$parameter->name}' of '{$this->resolving}::__construct' does not have a default value.");
 			}

--- a/src/tad/DI52/Container.php
+++ b/src/tad/DI52/Container.php
@@ -824,7 +824,7 @@ class tad_DI52_Container implements ArrayAccess {
 			$parameterClass = $parameter->getClass()->getName();
 		}
 
-    if (!$this->isBound($parameterClass) && !$parameter->getClass()->isInstantiable() && !isset($this->contexts[$parameterClass])) {
+        if (!$this->isBound($parameterClass) && !$parameter->getClass()->isInstantiable() && !isset($this->contexts[$parameterClass])) {
 			if (!$parameter->isDefaultValueAvailable()) {
 				throw new ReflectionException("parameter '{$parameter->name}' of '{$this->resolving}::__construct' does not have a default value.");
 			}

--- a/src/tad/DI52/Container.php
+++ b/src/tad/DI52/Container.php
@@ -824,7 +824,7 @@ class tad_DI52_Container implements ArrayAccess {
 			$parameterClass = $parameter->getClass()->getName();
 		}
 
-        if (!$this->isBound($parameterClass) && !$parameter->getClass()->isInstantiable() && !isset($this->contexts[$parameterClass])) {
+        if (!$this->isBound($parameterClass) && !$class->isInstantiable() && !isset($this->contexts[$parameterClass])) {
 			if (!$parameter->isDefaultValueAvailable()) {
 				throw new ReflectionException("parameter '{$parameter->name}' of '{$this->resolving}::__construct' does not have a default value.");
 			}

--- a/tests/53-above/Container53CompatTest.php
+++ b/tests/53-above/Container53CompatTest.php
@@ -810,15 +810,26 @@ class Container53CompatTest extends \PHPUnit_Framework_TestCase
 	}
 
 	/** @test */
-	public function it_should_give_when_need_without_a_bind() {
+	public function it_should_resolve_contextual_binding_without_an_early_bind() {
         $container = new tad_DI52_Container();
 
         $container->when(ClassSix::class)
                   ->needs(One::class)
                   ->give(ClassOne::class);
 
-        $six = $container->make(ClassSix::class);
+        $this->assertInstanceOf(ClassOne::class, $container->make(ClassSix::class)->getOne());
+	}
 
-        $this->assertInstanceOf(ClassOne::class, $six->getOne());
+	/** @test */
+	public function it_should_resolve_contextual_binding_with_an_early_bind_of_different_type() {
+        $container = new tad_DI52_Container();
+
+        $container->bind(One::class, 'foo');
+
+        $container->when(ClassSix::class)
+                  ->needs(One::class)
+                  ->give(ClassOne::class);
+
+        $this->assertInstanceOf(ClassOne::class, $container->make(ClassSix::class)->getOne());
 	}
 }

--- a/tests/53-above/Container53CompatTest.php
+++ b/tests/53-above/Container53CompatTest.php
@@ -813,23 +813,23 @@ class Container53CompatTest extends \PHPUnit_Framework_TestCase
 	public function it_should_resolve_contextual_binding_without_an_early_bind() {
         $container = new tad_DI52_Container();
 
-        $container->when(ClassSix::class)
-                  ->needs(One::class)
-                  ->give(ClassOne::class);
+        $container->when('ClassSix')
+                  ->needs('One')
+                  ->give('ClassOne');
 
-        $this->assertInstanceOf(ClassOne::class, $container->make(ClassSix::class)->getOne());
+        $this->assertInstanceOf('ClassOne', $container->make('ClassSix')->getOne());
 	}
 
 	/** @test */
 	public function it_should_resolve_contextual_binding_with_an_early_bind_of_different_type() {
         $container = new tad_DI52_Container();
 
-        $container->bind(One::class, 'foo');
+        $container->bind('One', 'foo');
 
-        $container->when(ClassSix::class)
-                  ->needs(One::class)
-                  ->give(ClassOne::class);
+        $container->when('ClassSix')
+                  ->needs('One')
+                  ->give('ClassOne');
 
-        $this->assertInstanceOf(ClassOne::class, $container->make(ClassSix::class)->getOne());
+        $this->assertInstanceOf('ClassOne', $container->make('ClassSix')->getOne());
 	}
 }

--- a/tests/53-above/Container53CompatTest.php
+++ b/tests/53-above/Container53CompatTest.php
@@ -808,4 +808,17 @@ class Container53CompatTest extends \PHPUnit_Framework_TestCase
 
 		$container->bind('PrivateConstructor');
 	}
+
+	/** @test */
+	public function it_should_give_when_need_without_a_bind() {
+        $container = new tad_DI52_Container();
+
+        $container->when(ClassSix::class)
+                  ->needs(One::class)
+                  ->give(ClassOne::class);
+
+        $six = $container->make(ClassSix::class);
+
+        $this->assertInstanceOf(ClassOne::class, $six->getOne());
+	}
 }


### PR DESCRIPTION
### The problem

When resolving a contextual binding, the Container can't resolve an interface that hasn't been bound at least once before.

This test fails:

```php
/** @test */
public function it_should_resolve_contextual_binding_without_an_early_bind() {
    $container = new tad_DI52_Container();

    $container->when('ClassSix')
              ->needs('One')
              ->give('ClassOne');

    $this->assertInstanceOf('ClassOne', $container->make('ClassSix')->getOne());
}
```

This works:

```php
/** @test */
public function it_should_resolve_contextual_binding_with_an_early_bind_of_different_type() {
    $container = new tad_DI52_Container();

    $container->bind('One', 'foo');

    $container->when('ClassSix')
              ->needs('One')
              ->give('ClassOne');

    $this->assertInstanceOf('ClassOne', $container->make('ClassSix')->getOne());
}
```

### The solution

This PR fixes this behavior by avoiding an early bail that prevents the given class to be resolved when it wasn't bound yet. Both tests above passes now.