### PR TITLE
Update .phpstorm.meta.php

### DIFF
--- a/.phpstorm.meta.php
+++ b/.phpstorm.meta.php
@@ -1,12 +1,21 @@
 <?php
 
 namespace PHPSTORM_META {
-	$STATIC_METHOD_TYPES = [
-		\tad_DI52_Container::make( '' ) => [
-			"" == "@",
-		],
+    $STATIC_METHOD_TYPES = [
+        \tad_DI52_Container::make( '' ) => [
+            "" == "@",
+        ],
+        \lucatume\DI52\Container::make( '' ) => [
+            "" == "@",
+        ],
         \lucatume\DI52\Container::get( '' ) => [
             "" == "@",
         ],
-	];
+        \lucatume\DI52\App::make( '' ) => [
+            "" == "@",
+        ],
+        \lucatume\DI52\App::get( '' ) => [
+            "" == "@",
+        ],
+    ];
 }


### PR DESCRIPTION
- Expands PHPStorm meta to cover more use cases.
- Normalize spacing as spaces instead of tabs.

To test:

1. Place this file in the root of your project
2. `App::get(Foo::class)->do_<tab>foo();`
3. Similar for all variations covered