### PR TITLE
Remove benchmark, lowering the size of the package

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+/_build export-ignore
+/tests export-ignore
+/.phan export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,8 @@
 /_build export-ignore
 /tests export-ignore
 /.phan export-ignore
+/.github export-ignore
+/makefile export-ignore
+/test-constructor.php export-ignore
+/phpunit.xml export-ignore
+/phpcs.xml export-ignore

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ composer.lock
 _build/profile/callgrind.out.*
 _build/benchmark/vendor
 .phpunit.result.cache
+release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased] Unreleased
 
+## [3.0.1] 2022-11-05;
+
 ## [3.0.0] 2022-02-09;
 
 ### Changed
@@ -400,4 +402,5 @@ org/psr/psr-11/)
 [2.1.4]: https://github.com/lucatume/di52/compare/2.1.3...2.1.4
 [2.1.5]: https://github.com/lucatume/di52/compare/2.1.4...2.1.5
 [3.0.0]: https://github.com/lucatume/di52/compare/2.1.5...3.0.0
-[unreleased]: https://github.com/lucatume/di52/compare/3.0.0...HEAD
+[3.0.1]: https://github.com/lucatume/di52/compare/3.0.0...3.0.1
+[unreleased]: https://github.com/lucatume/di52/compare/3.0.1...HEAD

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased] Unreleased
 
+## [3.0.2] 2022-11-05;
+
 ## [3.0.1] 2022-11-05;
 
 ## [3.0.0] 2022-02-09;
@@ -403,4 +405,5 @@ org/psr/psr-11/)
 [2.1.5]: https://github.com/lucatume/di52/compare/2.1.4...2.1.5
 [3.0.0]: https://github.com/lucatume/di52/compare/2.1.5...3.0.0
 [3.0.1]: https://github.com/lucatume/di52/compare/3.0.0...3.0.1
-[unreleased]: https://github.com/lucatume/di52/compare/3.0.1...HEAD
+[3.0.2]: https://github.com/lucatume/di52/compare/3.0.1...3.0.2
+[unreleased]: https://github.com/lucatume/di52/compare/3.0.2...HEAD

--- a/_build/release.php
+++ b/_build/release.php
@@ -223,86 +223,9 @@ if ($args('checkUnpushed', true) && !$dryRun) {
     }
 }
 
-$written = file_put_contents($root . '/.rel', $fullReleaseNotes);
+file_put_contents($root . '/.rel', $fullReleaseNotes);
 
-if ( $written === false ) {
-	echo "Could not write .rel file\n";
-	die( 1 );
-}
-
-$createZip = true;
-
-if ( $createZip ) {
-	if ( ! file_exists( "$root/release" ) ) {
-		mkdir( "$root/release" );
-	}
-
-	$zip = new \ZipArchive;
-	if ( $zip->open( "$root/release/$releaseVersion.zip", \ZipArchive::CREATE ) !== true ) {
-		echo "Could not initialize release zip file.";
-		die( 1 );
-	}
-
-	$ignoreTrainlingSlash = static function ( $v ) {
-		return rtrim( $v, '/' );
-	};
-
-	$doNotIncludeInRelease = array_merge( [
-		'.git',
-		'.github',
-		'.phan',
-		'.rel',
-		'_build',
-		'tests',
-		'makefile',
-		'phpcs.xml',
-		'phpunit.xml',
-		'test-constructor.php',
-	], array_map( $ignoreTrainlingSlash, explode( "\n", file_get_contents( "$root/.gitignore" ) ) ) );
-
-	$zipVerbose = [];
-
-	$normalizePathInZip = static function ( $path ) use ( $root ) {
-		// /home/foo/di52/src/App.php => di52/src/App.php inside the zip file.
-		$root = rtrim( $root, '/' ) . '/';
-		$path = str_replace( $root, '', $path );
-		$path = 'di52/' . ltrim( $path, '/' );
-
-		return $path;
-	};
-
-	$it = new \FileSystemIterator( $root, \FileSystemIterator::SKIP_DOTS );
-	while ( $it->valid() ) {
-		if ( in_array($it->getBasename(), $doNotIncludeInRelease, true) ) {
-			$zipVerbose[] = sprintf( 'Skipped %s: %s', $it->isDir() ? 'dir' : 'file', $it->getPathname() );
-			$it->next();
-			continue;
-		} else {
-			if ($it->isDir()) {
-				$subDir = new \RecursiveDirectoryIterator( $it->getPathname(), \FileSystemIterator::SKIP_DOTS );
-				while( $subDir->valid() ) {
-					if ($subDir->isFile()) {
-						$zipVerbose[] = "Added file: {$subDir->getPathname()}";
-						$zip->addFile( $subDir->getPathname(), $normalizePathInZip( $subDir->getPathname() ) );
-					}
-					$subDir->next();
-				}
-			} else {
-				$zipVerbose[] = "Added file: {$it->getPathname()}";
-				$zip->addFile( $it->getPathname(), $normalizePathInZip( $it->getPathname() ) );
-			}
-		}
-		$it->next();
-	}
-
-	sort($zipVerbose);
-
-	echo implode("\n", $zipVerbose) . "\n";
-
-	$zip->close();
-}
-
-$releaseCommand = "gh release create -F $root/.rel $releaseVersion $root/release/$releaseVersion.zip";
+$releaseCommand = 'gh release create -F .rel ' . $releaseVersion;
 
 echo "Releasing with command: \e[32m" . $releaseCommand . "\e[0m\n\n";
 

--- a/_build/release.php
+++ b/_build/release.php
@@ -225,7 +225,7 @@ if ($args('checkUnpushed', true) && !$dryRun) {
 
 file_put_contents($root . '/.rel', $fullReleaseNotes);
 
-$releaseCommand = 'gh release create -F .rel ' . $releaseVersion;
+$releaseCommand = "gh release create -F $root/.rel $releaseVersion";
 
 echo "Releasing with command: \e[32m" . $releaseCommand . "\e[0m\n\n";
 

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
-  "name": "lucatume/di52",
-  "description": "A PHP 5.6 compatible dependency injection container.",
+  "name": "luc45/di52",
+  "description": "This is a fork to test the development package.",
   "license": "GPL-3.0",
   "authors": [
     {


### PR DESCRIPTION
Reduces the size of this package from 50mb~ to 1mb~ by removing the benchmarks.

Before:

```
➜  di52 git:(master) du -d 2 -h --exclude=.git
24K     ./tests/Builders
96K     ./tests/__snapshots__
56K     ./tests/data
328K    ./tests
8.0K    ./_build/profile
49M     ./_build/benchmark
36K     ./_build/containers
49M     ./_build
12K     ./.github/workflows
16K     ./.github
20K     ./.phan
56K     ./src/Builders
128K    ./src
50M     .
```

After:

```
➜  di52 git:(master) du -d 2 -h --exclude=.git
24K     ./tests/Builders
96K     ./tests/__snapshots__
56K     ./tests/data
328K    ./tests
8.0K    ./_build/profile
36K     ./_build/containers
80K     ./_build
12K     ./.github/workflows
16K     ./.github
20K     ./.phan
56K     ./src/Builders
128K    ./src
260K    ./.idea
920K    .
```

How long until Composer Packagist allows us to deploy builds or exclude folders...?

If you want to keep the benchmarks, it's probably better to download them on-demand, gitignored, or to run them in a separate repo.