### PR TITLE
Exclude development files from release

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+/_build export-ignore
+/tests export-ignore
+/.phan export-ignore
+/.github export-ignore
+/makefile export-ignore
+/test-constructor.php export-ignore
+/phpunit.xml export-ignore
+/phpcs.xml export-ignore


### PR DESCRIPTION
As mentioned in #39 , this PR excludes development files from a GitHub release, lowering the size of the package. It leverages the fact that Composer uses `--prefer-dist` by default, which provides the release artifact instead of `trunk` when available.