### PR TITLE
Allow Dependency Injection on Service Providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased] Unreleased
 
+### Added
+- The container now registers Service Providers using its own `Container::get()` method, instead of the `new` keyword. This allows Service Providers to utilize dependency injection. (thanks @defunctl).
+- Additional contextual binding examples for primitives + service provider documentation in the README.
+
 ## [3.0.2] 2023-01-20;
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -554,6 +554,14 @@ $container->bind(DbCache::class, function($container){
 $container->when(TransactionManager::class)
     ->needs(CacheInterface::class)
     ->give(DbCache::class);
+
+/*
+ * We can also bind primitives where the container doesn't know how to autowire
+ * them.
+ */
+$container->when(PaginationManager::class)
+    ->needs('$per_page')
+    ->give(25);
 ```
 
 ## Binding decorator chains

--- a/src/Container.php
+++ b/src/Container.php
@@ -88,7 +88,7 @@ class Container implements \ArrayAccess, ContainerInterface
     {
         $this->resolver = new Builders\Resolver($resolveUnboundAsSingletons);
         $this->builders = new Builders\Factory($this, $this->resolver);
-        $this->bind( Container::class, $this );
+        $this->bind(Container::class, $this);
     }
 
     /**

--- a/src/Container.php
+++ b/src/Container.php
@@ -450,7 +450,7 @@ class Container implements \ArrayAccess, ContainerInterface
     public function register($serviceProviderClass, ...$alias)
     {
         /** @var ServiceProvider $provider */
-        $provider = new $serviceProviderClass($this);
+        $provider = $this->get($serviceProviderClass);
         if (!$provider->isDeferred()) {
             $provider->register();
         } else {

--- a/src/Container.php
+++ b/src/Container.php
@@ -88,6 +88,7 @@ class Container implements \ArrayAccess, ContainerInterface
     {
         $this->resolver = new Builders\Resolver($resolveUnboundAsSingletons);
         $this->builders = new Builders\Factory($this, $this->resolver);
+        $this->bind( Container::class, $this );
     }
 
     /**

--- a/src/Container.php
+++ b/src/Container.php
@@ -88,7 +88,7 @@ class Container implements \ArrayAccess, ContainerInterface
     {
         $this->resolver = new Builders\Resolver($resolveUnboundAsSingletons);
         $this->builders = new Builders\Factory($this, $this->resolver);
-        $this->bind(Container::class, $this);
+        $this->singleton(Container::class, $this);
     }
 
     /**

--- a/tests/ContainerTest.php
+++ b/tests/ContainerTest.php
@@ -129,4 +129,25 @@ class ContainerTest extends TestCase
             $this->assertInstanceOf(NotFoundException::class, $e);
         }
     }
+
+    /**
+     * The container now registers itself inside itself (containerception).
+     *
+     * @test
+     */
+    public function it_should_contain_the_containers_own_instance()
+    {
+        $container = new Container();
+
+        $this->assertTrue($container->has(Container::class));
+        $this->assertSame($container, $container->get(Container::class));
+
+        $container->get(ClassOne::class);
+        $container->get(ClassOneOne::class);
+
+        $this->assertTrue($container->has(ClassOne::class));
+        $this->assertTrue($container->has(ClassOneOne::class));
+        $this->assertSame($container, $container->get(Container::class));
+    }
+
 }

--- a/tests/ServiceProviderTest.php
+++ b/tests/ServiceProviderTest.php
@@ -104,6 +104,71 @@ class AliasServiceProvider extends ServiceProvider
     }
 }
 
+class TestDependency
+{
+
+    public function getValue()
+    {
+        return 'test';
+    }
+}
+
+class TestProviderInjection extends ServiceProvider
+{
+
+    /**
+     * @var TestDependency
+     */
+    protected $dependency;
+
+    public function __construct(Container $container, TestDependency $dependency)
+    {
+        parent::__construct($container);
+
+        $this->dependency = $dependency;
+    }
+
+    public function register()
+    {
+        // TODO: Implement register() method.
+    }
+
+    public function getContainer() {
+        return $this->container;
+    }
+
+    public function getDependency()
+    {
+        return $this->dependency;
+    }
+}
+
+class TestProviderPrimitiveInjection extends ServiceProvider
+{
+
+    /**
+     * @var string
+     */
+    protected $value;
+
+    public function __construct(Container $container, $value)
+    {
+        parent::__construct($container);
+
+        $this->value = $value;
+    }
+
+    public function register()
+    {
+        // TODO: Implement register() method.
+    }
+
+    public function getValue()
+    {
+        return $this->value;
+    }
+}
+
 class ServiceProviderTest extends TestCase
 {
     /**
@@ -292,5 +357,44 @@ class ServiceProviderTest extends TestCase
             $container->getProvider(AliasServiceProvider::class),
             $container->getProvider('other-service-provider')
         );
+    }
+
+    /**
+     * Test we can create service providers with additional concrete dependencies.
+     *
+     * @test
+     */
+    public function should_automatically_inject_concrete_instances_into_extended_providers()
+    {
+        $container = new Container();
+
+        $container->register(TestProviderInjection::class);
+        $this->assertTrue($container->has(TestProviderInjection::class));
+        $this->assertTrue($container->has(TestDependency::class));
+
+        $provider = $container->get(TestProviderInjection::class);
+
+        $this->assertSame($container, $provider->getContainer());
+        $this->assertInstanceOf(TestDependency::class, $provider->getDependency());
+        $this->assertSame('test', $provider->getDependency()->getValue());
+    }
+
+    /**
+     * Test we can configure the container with providers that have primitives
+     * in their constructor.
+     *
+     * @test
+     */
+    public function should_allow_binding_providers_with_primitive_values()
+    {
+        $container = new Container();
+
+        $container->when(TestProviderPrimitiveInjection::class)
+            ->needs('$value')
+            ->give('test');
+
+        $container->register(TestProviderPrimitiveInjection::class);
+        $this->assertTrue($container->has(TestProviderPrimitiveInjection::class));
+        $this->assertSame('test', $container->get(TestProviderPrimitiveInjection::class)->getValue());
     }
 }


### PR DESCRIPTION
Previously, Service Providers were instantiated with the `new` keyword and only passed in the container as the single dependency. This prevented the service providers themselves from taking any external dependencies.

Now, Service Providers can benefit from auto-wiring when additional dependencies are required as it utilizes the container's own `get()` method to create the instance.

See the updated README for examples.