### PR TITLE
BUGFIX: Resolve contextual concretes when its bound interface is requested

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased] Unreleased
 
+### Fixed
+
+- Allow bound interfaces to properly resolve their concrete class when the concrete class has contextual bindings (thanks @defunctl). e.g. the following will now work properly:
+
+```php
+$container = new \lucatume\DI52\Container();
+$container->bind(SomeInterface::class, SomeClass::class);
+$container->when(Someclass:class)
+    ->needs('$num')
+    ->give(20);
+
+// This now works, properly resolving SomeClass::class.
+$instance = $container->get(SomeInterface::class);
+```
+
 ## [3.3.0] 2023-02-28;
 
 ### Breaking change

--- a/src/Builders/ClassBuilder.php
+++ b/src/Builders/ClassBuilder.php
@@ -55,6 +55,14 @@ class ClassBuilder implements BuilderInterface, ReinitializableBuilderInterface
     protected $resolver;
 
     /**
+     * Whether the $className is an implementation of $id
+     * and $id is an interface.
+     *
+     * @var bool
+     */
+    protected $isInterface = false;
+
+    /**
      * ClassBuilder constructor.
      *
      * @param string             $id                The identifier associated with this builder.
@@ -73,6 +81,13 @@ class ClassBuilder implements BuilderInterface, ReinitializableBuilderInterface
                 "nothing is bound to the '{$className}' id and it's not an existing or instantiable class."
             );
         }
+
+        $interfaces = class_implements( $className );
+
+        if ($interfaces && isset($interfaces[$id]) ) {
+            $this->isInterface = true;
+        }
+
         $this->id = $id;
         $this->className = $className;
         $this->afterBuildMethods = $afterBuildMethods;
@@ -194,10 +209,15 @@ class ClassBuilder implements BuilderInterface, ReinitializableBuilderInterface
 
         if ($paramClass) {
             $parameterImplementation = $this->resolver->whenNeedsGive($this->id, $paramClass);
+        } elseif ($this->isInterface) {
+            $name = $parameter->getName();
+            // If an interface was requested, resolve the underlying concrete class instead.
+            $parameterImplementation = $this->resolver->whenNeedsGive($this->className, "\$$name");
         } else {
             $name = $parameter->getName();
             $parameterImplementation = $this->resolver->whenNeedsGive($this->id, "\$$name");
         }
+
         try {
             return $parameterImplementation instanceof BuilderInterface ?
                 $parameterImplementation->build()

--- a/src/Builders/ClassBuilder.php
+++ b/src/Builders/ClassBuilder.php
@@ -82,9 +82,9 @@ class ClassBuilder implements BuilderInterface, ReinitializableBuilderInterface
             );
         }
 
-        $interfaces = class_implements( $className );
+        $interfaces = class_implements($className);
 
-        if ($interfaces && isset($interfaces[$id]) ) {
+        if ($interfaces && isset($interfaces[$id])) {
             $this->isInterface = true;
         }
 

--- a/tests/unit/ContextualBindingContainerTest.php
+++ b/tests/unit/ContextualBindingContainerTest.php
@@ -51,6 +51,41 @@ class ContextualBindingContainerTest extends TestCase
     /**
      * @test
      */
+    public function it_should_resolve_primitive_contextual_bindings_in_a_php7_class_when_its_bound_interface_is_resolved(
+    )
+    {
+        $container = new Container();
+
+        $container->bind(Test5Interface::class, Primitive53ConstructorClass::class);
+        $container->when(Primitive53ConstructorClass::class)
+            ->needs('$num')
+            ->give(15);
+
+        $container->when(Primitive53ConstructorClass::class)
+            ->needs('$hello')
+            ->give(function () {
+                return 'World';
+            });
+
+        $container->when(Primitive53ConstructorClass::class)
+            ->needs('$list')
+            ->give([
+                'one',
+                'two',
+            ]);
+
+        $instance = $container->get(Test5Interface::class);
+
+        $this->assertSame(15, $instance->num());
+        $this->assertInstanceOf(Concrete53Dependency::class, $instance->dependency());
+        $this->assertSame('World', $instance->hello());
+        $this->assertSame(['one', 'two'], $instance->getList());
+        $this->assertNull($instance->optional());
+    }
+
+    /**
+     * @test
+     */
     public function it_should_throw_container_exception_when_missing_bindings_in_a_PHP53_class()
     {
         $this->expectException(ContainerException::class);

--- a/tests/unit/PHP7ContextualBindingContainerTest.php
+++ b/tests/unit/PHP7ContextualBindingContainerTest.php
@@ -65,6 +65,41 @@ class PHP7ContextualBindingContainerTest extends TestCase
     /**
      * @test
      */
+    public function it_should_resolve_primitive_contextual_bindings_in_a_php7_class_when_its_bound_interface_is_resolved()
+    {
+        $container = new Container();
+
+        $container->bind( Test7Interface::class, Primitive7ConstructorClass::class );
+
+        $container->when(Primitive7ConstructorClass::class)
+            ->needs('$num')
+            ->give(15);
+
+        $container->when(Primitive7ConstructorClass::class)
+            ->needs('$hello')
+            ->give(function () {
+                return 'World';
+            });
+
+        $container->when(Primitive7ConstructorClass::class)
+            ->needs('$list')
+            ->give([
+                'one',
+                'two',
+            ]);
+
+        $instance = $container->get(Test7Interface::class);
+
+        $this->assertSame(15, $instance->num());
+        $this->assertInstanceOf(Concrete7Dependency::class, $instance->dependency());
+        $this->assertSame('World', $instance->hello());
+        $this->assertSame(['one', 'two'], $instance->list());
+        $this->assertNull($instance->optional());
+    }
+
+    /**
+     * @test
+     */
     public function it_should_throw_container_exception_when_missing_bindings_in_a_php7_class()
     {
         $this->expectException(ContainerException::class);

--- a/tests/unit/PHP8ContextualBindingContainerTest.php
+++ b/tests/unit/PHP8ContextualBindingContainerTest.php
@@ -65,6 +65,40 @@ class PHP8ContextualBindingContainerTest extends TestCase
     /**
      * @test
      */
+    public function it_should_resolve_primitive_contextual_bindings_in_a_php80_class_when_its_bound_interface_is_resolved()
+    {
+        $container = new Container();
+
+        $container->bind(Test8Interface::class, Primitive8ConstructorClass::class);
+        $container->when(Primitive8ConstructorClass::class)
+            ->needs('$num')
+            ->give(20);
+
+        $container->when(Primitive8ConstructorClass::class)
+            ->needs('$hello')
+            ->give(function () {
+                return 'World';
+            });
+
+        $container->when(Primitive8ConstructorClass::class)
+            ->needs('$list')
+            ->give([
+                'one',
+                'two',
+            ]);
+
+        $instance = $container->get(Test8Interface::class);
+
+        $this->assertSame(20, $instance->num());
+        $this->assertInstanceOf(Concrete8Dependency::class, $instance->dependency());
+        $this->assertSame('World', $instance->hello());
+        $this->assertSame(['one', 'two'], $instance->list());
+        $this->assertNull($instance->optional());
+    }
+
+    /**
+     * @test
+     */
     public function it_should_throw_container_exception_when_missing_bindings_in_a_php80_class()
     {
         $this->expectException(ContainerException::class);

--- a/tests/unit/data/test-contextual-classes-php.php
+++ b/tests/unit/data/test-contextual-classes-php.php
@@ -3,12 +3,17 @@
  * PHP5.3+ contextual binding test classes.
  */
 
+interface Test5Interface
+{
+
+}
+
 class Concrete53Dependency
 {
 
 }
 
-class Primitive53ConstructorClass
+class Primitive53ConstructorClass implements Test5Interface
 {
     /**
      * @var int

--- a/tests/unit/data/test-contextual-classes-php7.php
+++ b/tests/unit/data/test-contextual-classes-php7.php
@@ -3,12 +3,17 @@
  * PHP7+ contextual binding test classes.
  */
 
+interface Test7Interface
+{
+
+}
+
 class Concrete7Dependency
 {
 
 }
 
-class Primitive7ConstructorClass
+class Primitive7ConstructorClass implements Test7Interface
 {
 
     /**

--- a/tests/unit/data/test-contextual-classes-php8.php
+++ b/tests/unit/data/test-contextual-classes-php8.php
@@ -3,12 +3,17 @@
  * PHP8+ contextual binding test classes.
  */
 
+interface Test8Interface
+{
+
+}
+
 final class Concrete8Dependency
 {
 
 }
 
-final class Primitive8ConstructorClass
+final class Primitive8ConstructorClass implements Test8Interface
 {
 
     public function __construct(


### PR DESCRIPTION
Fixes this bug:

```php
$container = new \lucatume\DI52\Container();
$container->bind(SomeInterface::class, SomeClass::class);
$container->when(Someclass:class)
    ->needs('$num')
    ->give(20);

// This now works, properly resolving SomeClass::class.
$instance = $container->get(SomeInterface::class);
```

Previously, it would throw this exception:

```
lucatume\DI52\ContainerException : SomeInterface
	=> Error while making int $num: parameter $num is not optional and is not type-hinted: auto-wiring is not magic.
```