### PR TITLE
Fix the return type of the callback function in the Container class

### DIFF
--- a/src/Container.php
+++ b/src/Container.php
@@ -716,7 +716,7 @@ class Container implements ArrayAccess, ContainerInterface
      * @param string        $method           The method that should be called on the resolved implementation with the
      *                                        specified array arguments.
      *
-     * @return mixed The called method return value.
+     * @return callable The callback function.
      *
      * @throws ContainerException If the id is not a bound implementation or valid class name.
      */


### PR DESCRIPTION
Hi! 

This pull request fixes the return type of the `callback` function in the Container class, as it returns the callback and not the result of the function. 