### PR TITLE
Fix the return type of the callback function in the App class

### DIFF
--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -1,7 +1,0 @@
-version = 1
-
-[[analyzers]]
-name = "php"
-
-[[analyzers]]
-name = "shell"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased] Unreleased
 
+### Fixed
+
+- Return value of the `App::callback` method to be `callable` (thanks @estevao90).
+
 ## [3.3.2] 2023-04-07;
 
 ### Fixed

--- a/src/App.php
+++ b/src/App.php
@@ -448,7 +448,7 @@ class App
      * @param string        $method           The method that should be called on the resolved implementation with the
      *                                        specified array arguments.
      *
-     * @return mixed The called method return value.
+     * @return callable The callback function.
      *
      * @throws ContainerException If the id is not a bound implementation or valid class name.
      */


### PR DESCRIPTION
This pull request fixes the return type of the callback function in the App class, as it returns the callback and not the result of the function.