### PR TITLE
Fix has($id) and get($id) Method Signature to Align with Psr\Container\ContainerInterface

### DIFF
--- a/src/Container.php
+++ b/src/Container.php
@@ -206,7 +206,7 @@ class Container implements ArrayAccess, ContainerInterface
      *
      * @throws ContainerException Error while retrieving the entry.
      */
-    public function get($id)
+    public function get(string $id)
     {
         try {
             return $this->resolver->resolve($id, [$id]);
@@ -287,7 +287,7 @@ class Container implements ArrayAccess, ContainerInterface
      *
      * @return bool Whether the container contains a binding for an id or not.
      */
-    public function has($id)
+    public function has(string $id): bool
     {
         return $this->resolver->isBound($id) || class_exists($id);
     }


### PR DESCRIPTION
This Pull Request aims to resolve a critical type-hinting compatibility issue with the Psr\Container\ContainerInterface. The has($id) and get($id) methods in the lucatume\DI52\Container class currently does not match the method signature specified in Psr\Container\ContainerInterface.

**Context**

The issue manifests as a fatal PHP error that looks like this:

`PHP Fatal error: Declaration of lucatume\DI52\Container::has($id) must be compatible with Psr\Container\ContainerInterface::has(string $id): bool`

This issue may not appear in every instance due to various factors such as different PHP versions, error reporting levels, and specific code execution paths.