### PR TITLE
Add PHPStan Generics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased] Unreleased
 
+### Changed
+
+- Added [PHPStan generics](https://phpstan.org/blog/generics-in-php-using-phpdocs) to multiple classes. IDEs that support them will get autocompletion (.phpstorm.meta.php not required) if a fully-qualified class name is used, e.g. `$instance = $container->get( Test::class );`. 
+
 ## [3.3.4] 2023-06-20;
 
 ### Added

--- a/src/App.php
+++ b/src/App.php
@@ -86,22 +86,22 @@ class App
         static::container()->offsetSet($offset, $value);
     }
 
-    /**
-     * Binds an interface a class or a string slug to an implementation and will always return the same instance.
-     *
-     * @param string             $id                A class or interface fully qualified name or a string slug.
-     * @param mixed              $implementation    The implementation that should be bound to the alias(es); can be a
-     *                                              class name, an object or a closure.
-     * @param array<string>|null $afterBuildMethods An array of methods that should be called on the built
-     *                                              implementation after resolving it.
-     *
-     * @return void This method does not return any value.
-     * @throws ContainerException If there's any issue reflecting on the class, interface or the implementation.
-     */
-    public static function singleton($id, $implementation = null, array $afterBuildMethods = null)
-    {
-        static::container()->singleton($id, $implementation, $afterBuildMethods);
-    }
+	/**
+	 * Binds an interface a class or a string slug to an implementation and will always return the same instance.
+	 *
+	 * @param  string|class-string  $id                 A class or interface fully qualified name or a string slug.
+	 * @param  mixed                $implementation     The implementation that should be bound to the alias(es); can be a
+	 *                                                  class name, an object or a closure.
+	 * @param  string[]|null        $afterBuildMethods  An array of methods that should be called on the built
+	 *                                                  implementation after resolving it.
+	 *
+	 * @return void This method does not return any value.
+	 *
+	 * @throws ContainerException If there's any issue reflecting on the class, interface or the implementation.
+	 */
+	public static function singleton( $id, $implementation = null, array $afterBuildMethods = null ) {
+		static::container()->singleton( $id, $implementation, $afterBuildMethods );
+	}
 
     /**
      * Returns a variable stored in the container.
@@ -121,18 +121,18 @@ class App
         return static::container()->getVar($key, $default);
     }
 
-    /**
-     * Finds an entry of the container by its identifier and returns it.
-     *
-     * @param string $offset Identifier of the entry to look for.
-     *
-     * @return mixed The entry for an id.
-     *
-     * @return mixed The value for the offset.
-     *
-     * @throws ContainerException Error while retrieving the entry.
-     * @throws NotFoundException  No entry was found for **this** identifier.
-     */
+	/**
+	 * Finds an entry of the container by its identifier and returns it.
+	 *
+	 * @template T
+	 *
+	 * @param string|class-string<T> $offset Identifier of the entry to look for.
+	 *
+	 * @return T|mixed The value for the offset.
+	 *
+	 * @throws ContainerException Error while retrieving the entry.
+	 * @throws NotFoundException  No entry was found for **this** identifier.
+	 */
     public static function offsetGet($offset)
     {
         return static::container()->offsetGet($offset);
@@ -141,9 +141,11 @@ class App
     /**
      * Finds an entry of the container by its identifier and returns it.
      *
-     * @param string $id A fully qualified class or interface name or an already built object.
+     * @template T
      *
-     * @return mixed The entry for an id.
+     * @param string|class-string<T> $id A fully qualified class or interface name or an already built object.
+     *
+     * @return T|mixed The entry for an id.
      *
      * @throws ContainerException Error while retrieving the entry.
      */
@@ -152,19 +154,22 @@ class App
         return static::container()->get($id);
     }
 
-    /**
-     * Returns an instance of the class or object bound to an interface, class  or string slug if any, else it will try
-     * to automagically resolve the object to a usable instance.
-     *
-     * If the implementation has been bound as singleton using the `singleton` method
-     * or the ArrayAccess API then the implementation will be resolved just on the first request.
-     *
-     * @param string $id A fully qualified class or interface name or an already built object.
-     *
-     * @return mixed
-     * @throws ContainerException If the target of the make is not bound and is not a valid,
-     *                                              concrete, class name or there's any issue making the target.
-     */
+	/**
+	 * Returns an instance of the class or object bound to an interface, class  or string slug if any, else it will try
+	 * to automagically resolve the object to a usable instance.
+	 *
+	 * If the implementation has been bound as singleton using the `singleton` method
+	 * or the ArrayAccess API then the implementation will be resolved just on the first request.
+	 *
+	 * @template T
+	 *
+	 * @param string|class-string<T> $id A fully qualified class or interface name or an already built object.
+	 *
+	 * @return T|mixed
+	 *
+	 * @throws ContainerException If the target of the make is not bound and is not a valid,
+	 *                                              concrete, class name or there's any issue making the target.
+	 */
     public static function make($id)
     {
         return static::container()->make($id);
@@ -177,7 +182,7 @@ class App
      * `$container[$id]` returning true does not mean that `$container[$id]` will not throw an exception.
      * It does however mean that `$container[$id]` will not throw a `NotFoundExceptionInterface`.
      *
-     * @param string $offset An offset to check for.
+     * @param string|class-string $offset An offset to check for.
      *
      * @return boolean true on success or false on failure.
      */
@@ -193,7 +198,7 @@ class App
      * `has($id)` returning true does not mean that `get($id)` will not throw an exception.
      * It does however mean that `get($id)` will not throw a `NotFoundExceptionInterface`.
      *
-     * @param string $id Identifier of the entry to look for.
+     * @param string|class-string $id Identifier of the entry to look for.
      *
      * @return bool Whether the container contains a binding for an id or not.
      */
@@ -271,7 +276,7 @@ class App
      * If a provider overloads the `boot` method that method will be called when the `boot` method is called on the
      * container itself.
      *
-     * @param string $serviceProviderClass The fully-qualified Service Provider class name.
+     * @param class-string $serviceProviderClass The fully-qualified Service Provider class name.
      * @param string ...$alias             A list of aliases the provider should be registered with.
      * @return void This method does not return any value.
      * @throws ContainerException If the Service Provider is not correctly configured or there's an issue
@@ -287,20 +292,21 @@ class App
         static::container()->register($serviceProviderClass, ...$alias);
     }
 
-    /**
-     * Binds an interface, a class or a string slug to an implementation.
-     *
-     * Existing implementations are replaced.
-     *
-     * @param string             $id                A class or interface fully qualified name or a string slug.
-     * @param mixed              $implementation    The implementation that should be bound to the alias(es); can be a
-     *                                              class name, an object or a closure.
-     * @param array<string>|null $afterBuildMethods An array of methods that should be called on the built
-     *                                              implementation after resolving it.
-     *
-     * @return void The method does not return any value.
-     * @throws ContainerException      If there's an issue while trying to bind the implementation.
-     */
+	/**
+	 * Binds an interface, a class or a string slug to an implementation.
+	 *
+	 * Existing implementations are replaced.
+	 *
+	 * @param  string|class-string  $id                 A class or interface fully qualified name or a string slug.
+	 * @param  mixed                $implementation     The implementation that should be bound to the alias(es); can be a
+	 *                                                  class name, an object or a closure.
+	 * @param  string[]|null        $afterBuildMethods  An array of methods that should be called on the built
+	 *                                                  implementation after resolving it.
+	 *
+	 * @return void The method does not return any value.
+	 *
+	 * @throws ContainerException      If there's an issue while trying to bind the implementation.
+	 */
     public static function bind($id, $implementation = null, array $afterBuildMethods = null)
     {
         static::container()->bind($id, $implementation, $afterBuildMethods);
@@ -321,43 +327,42 @@ class App
         static::container()->boot();
     }
 
-    /**
-     * Binds a class, interface or string slug to a chain of implementations decorating a base
-     * object; the chain will be lazily resolved only on the first call.
-     *
-     * The base decorated object must be the last element of the array.
-     *
-     * @param string                        $id                The class, interface or slug the decorator chain should
-     *                                                         be bound to.
-     * @param array<string|object|callable> $decorators        An array of implementations that decorate an object.
-     * @param array<string>|null            $afterBuildMethods An array of methods that should be called on the
-     *                                                         instance after it has been built; the methods should not
-     *                                                         require any argument.
-     *
-     * @return void This method does not return any value.
-     * @throws ContainerException
-     */
+	/**
+	 * Binds a class, interface or string slug to a chain of implementations decorating a base
+	 * object; the chain will be lazily resolved only on the first call.
+	 * The base decorated object must be the last element of the array.
+	 *
+	 * @param  string|class-string            $id                 The class, interface or slug the decorator chain should
+	 *                                                            be bound to.
+	 * @param  array<string|object|callable>  $decorators         An array of implementations that decorate an object.
+	 * @param  string[]|null                  $afterBuildMethods  An array of methods that should be called on the
+	 *                                                            instance after it has been built; the methods should not
+	 *                                                            require any argument.
+	 *
+	 * @return void This method does not return any value.
+	 * @throws ContainerException
+	 */
     public static function singletonDecorators($id, $decorators, array $afterBuildMethods = null)
     {
         static::container()->singletonDecorators($id, $decorators, $afterBuildMethods);
     }
 
-    /**
-     * Binds a class, interface or string slug to to a chain of implementations decorating a
-     * base object.
-     *
-     * The base decorated object must be the last element of the array.
-     *
-     * @param string                        $id                The class, interface or slug the decorator chain should
-     *                                                         be bound to.
-     * @param array<string|object|callable> $decorators        An array of implementations that decorate an object.
-     * @param array<string>|null            $afterBuildMethods An array of methods that should be called on the
-     *                                                         instance after it has been built; the methods should not
-     *                                                         require any argument.
-     *
-     * @return void This method does not return any value.
-     * @throws ContainerException If there's any issue binding the decorators.
-     */
+	/**
+	 * Binds a class, interface or string slug to a chain of implementations decorating a
+	 * base object.
+	 *
+	 * The base decorated object must be the last element of the array.
+	 *
+	 * @param  string|class-string            $id                 The class, interface or slug the decorator chain should
+	 *                                                            be bound to.
+	 * @param  array<string|object|callable>  $decorators         An array of implementations that decorate an object.
+	 * @param  string[]|null                  $afterBuildMethods  An array of methods that should be called on the
+	 *                                                            instance after it has been built; the methods should not
+	 *                                                            require any argument.
+	 *
+	 * @return void This method does not return any value.
+	 * @throws ContainerException If there's any issue binding the decorators.
+	 */
     public static function bindDecorators($id, array $decorators, array $afterBuildMethods = null)
     {
         static::container()->bindDecorators($id, $decorators, $afterBuildMethods);
@@ -375,104 +380,102 @@ class App
         static::container()->offsetUnset($offset);
     }
 
-    /**
-     * Starts the `when->needs->give` chain for a contextual binding.
-     *
-     * @param string $class The fully qualified name of the requesting class.
-     *
-     * Example:
-     *
-     *      // Any class requesting an implementation of `LoggerInterface` will receive this implementation ...
-     *      $container->singleton('LoggerInterface', 'FilesystemLogger');
-     *      // But if the requesting class is `Worker` return another implementation
-     *      $container->when('Worker')
-     *          ->needs('LoggerInterface)
-     *          ->give('RemoteLogger);
-     *
-     * @return Container The container instance, to continue the when/needs/give chain.
-     */
+	/**
+	 * Starts the `when->needs->give` chain for a contextual binding.
+	 *
+	 * @param string|class-string $class The fully qualified name of the requesting class.
+	 *
+	 * Example:
+	 *
+	 *      // Any class requesting an implementation of `LoggerInterface` will receive this implementation ...
+	 *      $container->singleton('LoggerInterface', 'FilesystemLogger');
+	 *      // But if the requesting class is `Worker` return another implementation
+	 *      $container->when('Worker')
+	 *          ->needs('LoggerInterface')
+	 *          ->give('RemoteLogger');
+	 *
+	 * @return Container The container instance, to continue the when/needs/give chain.
+	 */
     public static function when($class)
     {
         return static::container()->when($class);
     }
 
-    /**
-     * Second step of the `when->needs->give` chain for a contextual binding.
-     *
-     * Example:
-     *
-     *      // Any class requesting an implementation of `LoggerInterface` will receive this implementation ...
-     *      $container->singleton('LoggerInterface', 'FilesystemLogger');
-     *      // But if the requesting class is `Worker` return another implementation.
-     *      $container->when('Worker')
-     *          ->needs('LoggerInterface)
-     *          ->give('RemoteLogger);
-     *
-     * @param string $id The class or interface needed by the class.
-     *
-     * @return Container The container instance, to continue the when/needs/give chain.
-     */
+	/**
+	 * Second step of the `when->needs->give` chain for a contextual binding.
+	 *
+	 * Example:
+	 *
+	 *      // Any class requesting an implementation of `LoggerInterface` will receive this implementation ...
+	 *      $container->singleton('LoggerInterface', 'FilesystemLogger');
+	 *      // But if the requesting class is `Worker` return another implementation.
+	 *      $container->when('Worker')
+	 *          ->needs('LoggerInterface')
+	 *          ->give('RemoteLogger');
+	 *
+	 * @param string|class-string $id The class or interface needed by the class.
+	 *
+	 * @return Container The container instance, to continue the when/needs/give chain.
+	 */
     public static function needs($id)
     {
         return static::container()->needs($id);
     }
 
-    /**
-     * Third step of the `when->needs->give` chain for a contextual binding.
-     *
-     * Example:
-     *
-     *      // any class requesting an implementation of `LoggerInterface` will receive this implementation...
-     *      $container->singleton('LoggerInterface', 'FilesystemLogger');
-     *      // but if the requesting class is `Worker` return another implementation
-     *      $container->when('Worker')
-     *          ->needs('LoggerInterface)
-     *          ->give('RemoteLogger);
-     *
-     * @param mixed $implementation The implementation specified
-     *
-     * @return void This method does not return any value.
-     * @throws NotFoundException
-     */
+	/**
+	 * Third step of the `when->needs->give` chain for a contextual binding.
+	 *
+	 * Example:
+	 *
+	 *      // any class requesting an implementation of `LoggerInterface` will receive this implementation...
+	 *      $container->singleton('LoggerInterface', 'FilesystemLogger');
+	 *      // but if the requesting class is `Worker` return another implementation
+	 *      $container->when('Worker')
+	 *          ->needs('LoggerInterface')
+	 *          ->give('RemoteLogger');
+	 *
+	 * @param mixed $implementation The implementation specified
+	 *
+	 * @return void This method does not return any value.
+	 * @throws NotFoundException
+	 */
     public static function give($implementation)
     {
         static::container()->give($implementation);
     }
 
-    /**
-     * Returns a lambda function suitable to use as a callback; when called the function will build the implementation
-     * bound to `$id` and return the value of a call to `$method` method with the call arguments.
-     *
-     * @param string|object $id               A fully-qualified class name, a bound slug or an object o call the
-     *                                        callback on.
-     * @param string        $method           The method that should be called on the resolved implementation with the
-     *                                        specified array arguments.
-     *
-     * @return callable The callback function.
-     *
-     * @throws ContainerException If the id is not a bound implementation or valid class name.
-     */
+	/**
+	 * Returns a lambda function suitable to use as a callback; when called the function will build the implementation
+	 * bound to `$id` and return the value of a call to `$method` method with the call arguments.
+	 *
+	 * @param  string|class-string|object  $id      A fully-qualified class name, a bound slug or an object o call the
+	 *                                              callback on.
+	 * @param  string                      $method  The method that should be called on the resolved implementation with the
+	 *                                              specified array arguments.
+	 *
+	 * @return callable|Closure The callback function.
+	 * @throws ContainerException If the id is not a bound implementation or valid class name.
+	 */
     public static function callback($id, $method)
     {
         return static::container()->callback($id, $method);
     }
 
-    /**
-     * Returns a callable object that will build an instance of the specified class using the
-     * specified arguments when called.
-     *
-     * The callable will be a closure on PHP 5.3+ or a lambda function on PHP 5.2.
-     *
-     * @param string|mixed       $id                The fully qualified name of a class or an interface.
-     * @param array<mixed>       $buildArgs         An array of arguments that should be used to build the instance;
-     *                                              note that any argument will be resolved using the container itself
-     *                                              and bindings will apply.
-     * @param array<string>|null $afterBuildMethods An array of methods that should be called on the built
-     *                                              implementation after resolving it.
-     *
-     * @return callable  A callable function that will return an instance of the specified class when
-     *                   called.
-     */
+	/**
+	 * Returns a callable object that will build an instance of the specified class using the
+	 * specified arguments when called.
+	 * The callable will be a closure on PHP 5.3+ or a lambda function on PHP 5.2.
+	 *
+	 * @param  string|class-string|mixed  $id                 The fully qualified name of a class or an interface.
+	 * @param  array<mixed>               $buildArgs          An array of arguments that should be used to build the instance;
+	 *                                                        note that any argument will be resolved using the container itself
+	 *                                                        and bindings will apply.
+	 * @param  string[]|null              $afterBuildMethods  An array of methods that should be called on the built
+	 *                                                        implementation after resolving it.
+	 *
+	 * @return callable|Closure  A callable function that will return an instance of the specified class when
+	 *                   called.
+	 */
     public static function instance($id, array $buildArgs = [], array $afterBuildMethods = null)
     {
         return static::container()->instance($id, $buildArgs, $afterBuildMethods);
@@ -493,7 +496,7 @@ class App
     /**
      * Returns the Service Provider instance registered.
      *
-     * @param string $providerId The Service Provider clas to return the instance for.
+     * @param string|class-string $providerId The Service Provider class to return the instance for.
      *
      * @return ServiceProvider The service provider instance.
      *
@@ -508,10 +511,10 @@ class App
     /**
      * Returns whether a binding exists in the container or not.
      *
-     * `isBound($id)` returning `true` means the a call to `bind($id, $implementaion)` or `singleton($id,
+     * `isBound($id)` returning `true` means the call to `bind($id, $implementaion)` or `singleton($id,
      * $implementation)` (or equivalent ArrayAccess methods) was explicitly made.
      *
-     * @param string $id The id to check for bindings in the container.
+     * @param string|class-string $id The id to check for bindings in the container.
      *
      * @return bool Whether an explicit binding for the id exists in the container or not.
      */

--- a/src/App.php
+++ b/src/App.php
@@ -127,9 +127,10 @@ class App
      *
      * @template T
      *
-     * @param string|class-string<T> $offset Identifier of the entry to look for.
+     * @param  string|class-string<T>  $offset  Identifier of the entry to look for.
      *
      * @return T|mixed The value for the offset.
+     * @phpstan-return ($offset is class-string ? T : mixed)
      *
      * @throws ContainerException Error while retrieving the entry.
      * @throws NotFoundException  No entry was found for **this** identifier.
@@ -147,6 +148,7 @@ class App
      * @param string|class-string<T> $id A fully qualified class or interface name or an already built object.
      *
      * @return T|mixed The entry for an id.
+     * @phpstan-return ($id is class-string ? T : mixed)
      *
      * @throws ContainerException Error while retrieving the entry.
      */
@@ -167,6 +169,7 @@ class App
      * @param string|class-string<T> $id A fully qualified class or interface name or an already built object.
      *
      * @return T|mixed
+     * @phpstan-return ($id is class-string ? T : mixed)
      *
      * @throws ContainerException If the target of the make is not bound and is not a valid,
      *                                              concrete, class name or there's any issue making the target.
@@ -454,7 +457,7 @@ class App
      * @param  string                      $method  The method that should be called on the resolved implementation
      *                                              with the specified array arguments.
      *
-     * @return callable|Closure The callback function.
+     * @return callable The callback function.
      * @throws ContainerException If the id is not a bound implementation or valid class name.
      */
     public static function callback($id, $method)
@@ -474,7 +477,7 @@ class App
      * @param  string[]|null              $afterBuildMethods  An array of methods that should be called on the built
      *                                                        implementation after resolving it.
      *
-     * @return callable|Closure  A callable function that will return an instance of the specified class when
+     * @return callable  A callable function that will return an instance of the specified class when
      *                   called.
      */
     public static function instance($id, array $buildArgs = [], array $afterBuildMethods = null)

--- a/src/App.php
+++ b/src/App.php
@@ -90,8 +90,8 @@ class App
      * Binds an interface a class or a string slug to an implementation and will always return the same instance.
      *
      * @param  string|class-string  $id                 A class or interface fully qualified name or a string slug.
-     * @param  mixed                $implementation     The implementation that should be bound to the alias(es); can be a
-     *                                                  class name, an object or a closure.
+     * @param  mixed                $implementation     The implementation that should be bound to the alias(es); can
+     *                                                  be a class name, an object or a closure.
      * @param  string[]|null        $afterBuildMethods  An array of methods that should be called on the built
      *                                                  implementation after resolving it.
      *
@@ -299,8 +299,8 @@ class App
      * Existing implementations are replaced.
      *
      * @param  string|class-string  $id                 A class or interface fully qualified name or a string slug.
-     * @param  mixed                $implementation     The implementation that should be bound to the alias(es); can be a
-     *                                                  class name, an object or a closure.
+     * @param  mixed                $implementation     The implementation that should be bound to the alias(es); can
+     *                                                  be a class name, an object or a closure.
      * @param  string[]|null        $afterBuildMethods  An array of methods that should be called on the built
      *                                                  implementation after resolving it.
      *
@@ -333,12 +333,12 @@ class App
      * object; the chain will be lazily resolved only on the first call.
      * The base decorated object must be the last element of the array.
      *
-     * @param  string|class-string            $id                 The class, interface or slug the decorator chain should
-     *                                                            be bound to.
+     * @param  string|class-string            $id                 The class, interface or slug the decorator chain
+     *                                                            should be bound to.
      * @param  array<string|object|callable>  $decorators         An array of implementations that decorate an object.
      * @param  string[]|null                  $afterBuildMethods  An array of methods that should be called on the
-     *                                                            instance after it has been built; the methods should not
-     *                                                            require any argument.
+     *                                                            instance after it has been built; the methods should
+     *                                                            not require any argument.
      *
      * @return void This method does not return any value.
      * @throws ContainerException
@@ -354,12 +354,12 @@ class App
      *
      * The base decorated object must be the last element of the array.
      *
-     * @param  string|class-string            $id                 The class, interface or slug the decorator chain should
-     *                                                            be bound to.
+     * @param  string|class-string            $id                 The class, interface or slug the decorator chain
+     *                                                            should be bound to.
      * @param  array<string|object|callable>  $decorators         An array of implementations that decorate an object.
      * @param  string[]|null                  $afterBuildMethods  An array of methods that should be called on the
-     *                                                            instance after it has been built; the methods should not
-     *                                                            require any argument.
+     *                                                            instance after it has been built; the methods should
+     *                                                            not require any argument.
      *
      * @return void This method does not return any value.
      * @throws ContainerException If there's any issue binding the decorators.
@@ -451,8 +451,8 @@ class App
      *
      * @param  string|class-string|object  $id      A fully-qualified class name, a bound slug or an object o call the
      *                                              callback on.
-     * @param  string                      $method  The method that should be called on the resolved implementation with the
-     *                                              specified array arguments.
+     * @param  string                      $method  The method that should be called on the resolved implementation
+     *                                              with the specified array arguments.
      *
      * @return callable|Closure The callback function.
      * @throws ContainerException If the id is not a bound implementation or valid class name.
@@ -468,9 +468,9 @@ class App
      * The callable will be a closure on PHP 5.3+ or a lambda function on PHP 5.2.
      *
      * @param  string|class-string|mixed  $id                 The fully qualified name of a class or an interface.
-     * @param  array<mixed>               $buildArgs          An array of arguments that should be used to build the instance;
-     *                                                        note that any argument will be resolved using the container itself
-     *                                                        and bindings will apply.
+     * @param  array<mixed>               $buildArgs          An array of arguments that should be used to build the
+     *                                                        instance; note that any argument will be resolved using
+     *                                                        the container itself and bindings will apply.
      * @param  string[]|null              $afterBuildMethods  An array of methods that should be called on the built
      *                                                        implementation after resolving it.
      *

--- a/src/App.php
+++ b/src/App.php
@@ -86,22 +86,23 @@ class App
         static::container()->offsetSet($offset, $value);
     }
 
-	/**
-	 * Binds an interface a class or a string slug to an implementation and will always return the same instance.
-	 *
-	 * @param  string|class-string  $id                 A class or interface fully qualified name or a string slug.
-	 * @param  mixed                $implementation     The implementation that should be bound to the alias(es); can be a
-	 *                                                  class name, an object or a closure.
-	 * @param  string[]|null        $afterBuildMethods  An array of methods that should be called on the built
-	 *                                                  implementation after resolving it.
-	 *
-	 * @return void This method does not return any value.
-	 *
-	 * @throws ContainerException If there's any issue reflecting on the class, interface or the implementation.
-	 */
-	public static function singleton( $id, $implementation = null, array $afterBuildMethods = null ) {
-		static::container()->singleton( $id, $implementation, $afterBuildMethods );
-	}
+    /**
+     * Binds an interface a class or a string slug to an implementation and will always return the same instance.
+     *
+     * @param  string|class-string  $id                 A class or interface fully qualified name or a string slug.
+     * @param  mixed                $implementation     The implementation that should be bound to the alias(es); can be a
+     *                                                  class name, an object or a closure.
+     * @param  string[]|null        $afterBuildMethods  An array of methods that should be called on the built
+     *                                                  implementation after resolving it.
+     *
+     * @return void This method does not return any value.
+     *
+     * @throws ContainerException If there's any issue reflecting on the class, interface or the implementation.
+     */
+    public static function singleton($id, $implementation = null, array $afterBuildMethods = null)
+    {
+        static::container()->singleton($id, $implementation, $afterBuildMethods);
+    }
 
     /**
      * Returns a variable stored in the container.
@@ -121,18 +122,18 @@ class App
         return static::container()->getVar($key, $default);
     }
 
-	/**
-	 * Finds an entry of the container by its identifier and returns it.
-	 *
-	 * @template T
-	 *
-	 * @param string|class-string<T> $offset Identifier of the entry to look for.
-	 *
-	 * @return T|mixed The value for the offset.
-	 *
-	 * @throws ContainerException Error while retrieving the entry.
-	 * @throws NotFoundException  No entry was found for **this** identifier.
-	 */
+    /**
+     * Finds an entry of the container by its identifier and returns it.
+     *
+     * @template T
+     *
+     * @param string|class-string<T> $offset Identifier of the entry to look for.
+     *
+     * @return T|mixed The value for the offset.
+     *
+     * @throws ContainerException Error while retrieving the entry.
+     * @throws NotFoundException  No entry was found for **this** identifier.
+     */
     public static function offsetGet($offset)
     {
         return static::container()->offsetGet($offset);
@@ -154,22 +155,22 @@ class App
         return static::container()->get($id);
     }
 
-	/**
-	 * Returns an instance of the class or object bound to an interface, class  or string slug if any, else it will try
-	 * to automagically resolve the object to a usable instance.
-	 *
-	 * If the implementation has been bound as singleton using the `singleton` method
-	 * or the ArrayAccess API then the implementation will be resolved just on the first request.
-	 *
-	 * @template T
-	 *
-	 * @param string|class-string<T> $id A fully qualified class or interface name or an already built object.
-	 *
-	 * @return T|mixed
-	 *
-	 * @throws ContainerException If the target of the make is not bound and is not a valid,
-	 *                                              concrete, class name or there's any issue making the target.
-	 */
+    /**
+     * Returns an instance of the class or object bound to an interface, class  or string slug if any, else it will try
+     * to automagically resolve the object to a usable instance.
+     *
+     * If the implementation has been bound as singleton using the `singleton` method
+     * or the ArrayAccess API then the implementation will be resolved just on the first request.
+     *
+     * @template T
+     *
+     * @param string|class-string<T> $id A fully qualified class or interface name or an already built object.
+     *
+     * @return T|mixed
+     *
+     * @throws ContainerException If the target of the make is not bound and is not a valid,
+     *                                              concrete, class name or there's any issue making the target.
+     */
     public static function make($id)
     {
         return static::container()->make($id);
@@ -292,21 +293,21 @@ class App
         static::container()->register($serviceProviderClass, ...$alias);
     }
 
-	/**
-	 * Binds an interface, a class or a string slug to an implementation.
-	 *
-	 * Existing implementations are replaced.
-	 *
-	 * @param  string|class-string  $id                 A class or interface fully qualified name or a string slug.
-	 * @param  mixed                $implementation     The implementation that should be bound to the alias(es); can be a
-	 *                                                  class name, an object or a closure.
-	 * @param  string[]|null        $afterBuildMethods  An array of methods that should be called on the built
-	 *                                                  implementation after resolving it.
-	 *
-	 * @return void The method does not return any value.
-	 *
-	 * @throws ContainerException      If there's an issue while trying to bind the implementation.
-	 */
+    /**
+     * Binds an interface, a class or a string slug to an implementation.
+     *
+     * Existing implementations are replaced.
+     *
+     * @param  string|class-string  $id                 A class or interface fully qualified name or a string slug.
+     * @param  mixed                $implementation     The implementation that should be bound to the alias(es); can be a
+     *                                                  class name, an object or a closure.
+     * @param  string[]|null        $afterBuildMethods  An array of methods that should be called on the built
+     *                                                  implementation after resolving it.
+     *
+     * @return void The method does not return any value.
+     *
+     * @throws ContainerException      If there's an issue while trying to bind the implementation.
+     */
     public static function bind($id, $implementation = null, array $afterBuildMethods = null)
     {
         static::container()->bind($id, $implementation, $afterBuildMethods);
@@ -327,42 +328,42 @@ class App
         static::container()->boot();
     }
 
-	/**
-	 * Binds a class, interface or string slug to a chain of implementations decorating a base
-	 * object; the chain will be lazily resolved only on the first call.
-	 * The base decorated object must be the last element of the array.
-	 *
-	 * @param  string|class-string            $id                 The class, interface or slug the decorator chain should
-	 *                                                            be bound to.
-	 * @param  array<string|object|callable>  $decorators         An array of implementations that decorate an object.
-	 * @param  string[]|null                  $afterBuildMethods  An array of methods that should be called on the
-	 *                                                            instance after it has been built; the methods should not
-	 *                                                            require any argument.
-	 *
-	 * @return void This method does not return any value.
-	 * @throws ContainerException
-	 */
+    /**
+     * Binds a class, interface or string slug to a chain of implementations decorating a base
+     * object; the chain will be lazily resolved only on the first call.
+     * The base decorated object must be the last element of the array.
+     *
+     * @param  string|class-string            $id                 The class, interface or slug the decorator chain should
+     *                                                            be bound to.
+     * @param  array<string|object|callable>  $decorators         An array of implementations that decorate an object.
+     * @param  string[]|null                  $afterBuildMethods  An array of methods that should be called on the
+     *                                                            instance after it has been built; the methods should not
+     *                                                            require any argument.
+     *
+     * @return void This method does not return any value.
+     * @throws ContainerException
+     */
     public static function singletonDecorators($id, $decorators, array $afterBuildMethods = null)
     {
         static::container()->singletonDecorators($id, $decorators, $afterBuildMethods);
     }
 
-	/**
-	 * Binds a class, interface or string slug to a chain of implementations decorating a
-	 * base object.
-	 *
-	 * The base decorated object must be the last element of the array.
-	 *
-	 * @param  string|class-string            $id                 The class, interface or slug the decorator chain should
-	 *                                                            be bound to.
-	 * @param  array<string|object|callable>  $decorators         An array of implementations that decorate an object.
-	 * @param  string[]|null                  $afterBuildMethods  An array of methods that should be called on the
-	 *                                                            instance after it has been built; the methods should not
-	 *                                                            require any argument.
-	 *
-	 * @return void This method does not return any value.
-	 * @throws ContainerException If there's any issue binding the decorators.
-	 */
+    /**
+     * Binds a class, interface or string slug to a chain of implementations decorating a
+     * base object.
+     *
+     * The base decorated object must be the last element of the array.
+     *
+     * @param  string|class-string            $id                 The class, interface or slug the decorator chain should
+     *                                                            be bound to.
+     * @param  array<string|object|callable>  $decorators         An array of implementations that decorate an object.
+     * @param  string[]|null                  $afterBuildMethods  An array of methods that should be called on the
+     *                                                            instance after it has been built; the methods should not
+     *                                                            require any argument.
+     *
+     * @return void This method does not return any value.
+     * @throws ContainerException If there's any issue binding the decorators.
+     */
     public static function bindDecorators($id, array $decorators, array $afterBuildMethods = null)
     {
         static::container()->bindDecorators($id, $decorators, $afterBuildMethods);
@@ -380,102 +381,102 @@ class App
         static::container()->offsetUnset($offset);
     }
 
-	/**
-	 * Starts the `when->needs->give` chain for a contextual binding.
-	 *
-	 * @param string|class-string $class The fully qualified name of the requesting class.
-	 *
-	 * Example:
-	 *
-	 *      // Any class requesting an implementation of `LoggerInterface` will receive this implementation ...
-	 *      $container->singleton('LoggerInterface', 'FilesystemLogger');
-	 *      // But if the requesting class is `Worker` return another implementation
-	 *      $container->when('Worker')
-	 *          ->needs('LoggerInterface')
-	 *          ->give('RemoteLogger');
-	 *
-	 * @return Container The container instance, to continue the when/needs/give chain.
-	 */
+    /**
+     * Starts the `when->needs->give` chain for a contextual binding.
+     *
+     * @param string|class-string $class The fully qualified name of the requesting class.
+     *
+     * Example:
+     *
+     *      // Any class requesting an implementation of `LoggerInterface` will receive this implementation ...
+     *      $container->singleton('LoggerInterface', 'FilesystemLogger');
+     *      // But if the requesting class is `Worker` return another implementation
+     *      $container->when('Worker')
+     *          ->needs('LoggerInterface')
+     *          ->give('RemoteLogger');
+     *
+     * @return Container The container instance, to continue the when/needs/give chain.
+     */
     public static function when($class)
     {
         return static::container()->when($class);
     }
 
-	/**
-	 * Second step of the `when->needs->give` chain for a contextual binding.
-	 *
-	 * Example:
-	 *
-	 *      // Any class requesting an implementation of `LoggerInterface` will receive this implementation ...
-	 *      $container->singleton('LoggerInterface', 'FilesystemLogger');
-	 *      // But if the requesting class is `Worker` return another implementation.
-	 *      $container->when('Worker')
-	 *          ->needs('LoggerInterface')
-	 *          ->give('RemoteLogger');
-	 *
-	 * @param string|class-string $id The class or interface needed by the class.
-	 *
-	 * @return Container The container instance, to continue the when/needs/give chain.
-	 */
+    /**
+     * Second step of the `when->needs->give` chain for a contextual binding.
+     *
+     * Example:
+     *
+     *      // Any class requesting an implementation of `LoggerInterface` will receive this implementation ...
+     *      $container->singleton('LoggerInterface', 'FilesystemLogger');
+     *      // But if the requesting class is `Worker` return another implementation.
+     *      $container->when('Worker')
+     *          ->needs('LoggerInterface')
+     *          ->give('RemoteLogger');
+     *
+     * @param string|class-string $id The class or interface needed by the class.
+     *
+     * @return Container The container instance, to continue the when/needs/give chain.
+     */
     public static function needs($id)
     {
         return static::container()->needs($id);
     }
 
-	/**
-	 * Third step of the `when->needs->give` chain for a contextual binding.
-	 *
-	 * Example:
-	 *
-	 *      // any class requesting an implementation of `LoggerInterface` will receive this implementation...
-	 *      $container->singleton('LoggerInterface', 'FilesystemLogger');
-	 *      // but if the requesting class is `Worker` return another implementation
-	 *      $container->when('Worker')
-	 *          ->needs('LoggerInterface')
-	 *          ->give('RemoteLogger');
-	 *
-	 * @param mixed $implementation The implementation specified
-	 *
-	 * @return void This method does not return any value.
-	 * @throws NotFoundException
-	 */
+    /**
+     * Third step of the `when->needs->give` chain for a contextual binding.
+     *
+     * Example:
+     *
+     *      // any class requesting an implementation of `LoggerInterface` will receive this implementation...
+     *      $container->singleton('LoggerInterface', 'FilesystemLogger');
+     *      // but if the requesting class is `Worker` return another implementation
+     *      $container->when('Worker')
+     *          ->needs('LoggerInterface')
+     *          ->give('RemoteLogger');
+     *
+     * @param mixed $implementation The implementation specified
+     *
+     * @return void This method does not return any value.
+     * @throws NotFoundException
+     */
     public static function give($implementation)
     {
         static::container()->give($implementation);
     }
 
-	/**
-	 * Returns a lambda function suitable to use as a callback; when called the function will build the implementation
-	 * bound to `$id` and return the value of a call to `$method` method with the call arguments.
-	 *
-	 * @param  string|class-string|object  $id      A fully-qualified class name, a bound slug or an object o call the
-	 *                                              callback on.
-	 * @param  string                      $method  The method that should be called on the resolved implementation with the
-	 *                                              specified array arguments.
-	 *
-	 * @return callable|Closure The callback function.
-	 * @throws ContainerException If the id is not a bound implementation or valid class name.
-	 */
+    /**
+     * Returns a lambda function suitable to use as a callback; when called the function will build the implementation
+     * bound to `$id` and return the value of a call to `$method` method with the call arguments.
+     *
+     * @param  string|class-string|object  $id      A fully-qualified class name, a bound slug or an object o call the
+     *                                              callback on.
+     * @param  string                      $method  The method that should be called on the resolved implementation with the
+     *                                              specified array arguments.
+     *
+     * @return callable|Closure The callback function.
+     * @throws ContainerException If the id is not a bound implementation or valid class name.
+     */
     public static function callback($id, $method)
     {
         return static::container()->callback($id, $method);
     }
 
-	/**
-	 * Returns a callable object that will build an instance of the specified class using the
-	 * specified arguments when called.
-	 * The callable will be a closure on PHP 5.3+ or a lambda function on PHP 5.2.
-	 *
-	 * @param  string|class-string|mixed  $id                 The fully qualified name of a class or an interface.
-	 * @param  array<mixed>               $buildArgs          An array of arguments that should be used to build the instance;
-	 *                                                        note that any argument will be resolved using the container itself
-	 *                                                        and bindings will apply.
-	 * @param  string[]|null              $afterBuildMethods  An array of methods that should be called on the built
-	 *                                                        implementation after resolving it.
-	 *
-	 * @return callable|Closure  A callable function that will return an instance of the specified class when
-	 *                   called.
-	 */
+    /**
+     * Returns a callable object that will build an instance of the specified class using the
+     * specified arguments when called.
+     * The callable will be a closure on PHP 5.3+ or a lambda function on PHP 5.2.
+     *
+     * @param  string|class-string|mixed  $id                 The fully qualified name of a class or an interface.
+     * @param  array<mixed>               $buildArgs          An array of arguments that should be used to build the instance;
+     *                                                        note that any argument will be resolved using the container itself
+     *                                                        and bindings will apply.
+     * @param  string[]|null              $afterBuildMethods  An array of methods that should be called on the built
+     *                                                        implementation after resolving it.
+     *
+     * @return callable|Closure  A callable function that will return an instance of the specified class when
+     *                   called.
+     */
     public static function instance($id, array $buildArgs = [], array $afterBuildMethods = null)
     {
         return static::container()->instance($id, $buildArgs, $afterBuildMethods);

--- a/src/Builders/ClassBuilder.php
+++ b/src/Builders/ClassBuilder.php
@@ -62,18 +62,18 @@ class ClassBuilder implements BuilderInterface, ReinitializableBuilderInterface
      */
     protected $isInterface = false;
 
-	/**
-	 * ClassBuilder constructor.
-	 *
-	 * @param  string|class-string  $id                 The identifier associated with this builder.
-	 * @param  Resolver             $resolver           A reference to the resolver currently using the builder.
-	 * @param  string               $className          The fully-qualified class name to build instances for.
-	 * @param  string[]|null        $afterBuildMethods  An optional set of methods to call on the built object.
-	 * @param  mixed                ...$buildArgs       An optional set of build arguments that should be provided to the
-	 *                                                  class constructor method.
-	 *
-	 * @throws NotFoundException If the class does not exist.
-	 */
+    /**
+     * ClassBuilder constructor.
+     *
+     * @param  string|class-string  $id                 The identifier associated with this builder.
+     * @param  Resolver             $resolver           A reference to the resolver currently using the builder.
+     * @param  string               $className          The fully-qualified class name to build instances for.
+     * @param  string[]|null        $afterBuildMethods  An optional set of methods to call on the built object.
+     * @param  mixed                ...$buildArgs       An optional set of build arguments that should be provided to the
+     *                                                  class constructor method.
+     *
+     * @throws NotFoundException If the class does not exist.
+     */
     public function __construct($id, Resolver $resolver, $className, array $afterBuildMethods = null, ...$buildArgs)
     {
         if (!class_exists($className)) {
@@ -142,15 +142,15 @@ class ClassBuilder implements BuilderInterface, ReinitializableBuilderInterface
         return $constructorArgs;
     }
 
-	/**
-	 * Returns a set of resolved constructor parameters.
-	 *
-	 * @param  class-string  $className  The fully-qualified class name to get the resolved constructor parameters yet.
-	 *
-	 * @return array<Parameter> A set of resolved constructor parameters.
-	 *
-	 * @throws ContainerException If the resolution of any constructor parameters is problematic.
-	 */
+    /**
+     * Returns a set of resolved constructor parameters.
+     *
+     * @param  class-string  $className  The fully-qualified class name to get the resolved constructor parameters yet.
+     *
+     * @return array<Parameter> A set of resolved constructor parameters.
+     *
+     * @throws ContainerException If the resolution of any constructor parameters is problematic.
+     */
     protected function getResolvedConstructorParameters($className)
     {
         if (isset(self::$constructorParametersCache[$className])) {

--- a/src/Builders/ClassBuilder.php
+++ b/src/Builders/ClassBuilder.php
@@ -69,8 +69,8 @@ class ClassBuilder implements BuilderInterface, ReinitializableBuilderInterface
      * @param  Resolver             $resolver           A reference to the resolver currently using the builder.
      * @param  string               $className          The fully-qualified class name to build instances for.
      * @param  string[]|null        $afterBuildMethods  An optional set of methods to call on the built object.
-     * @param  mixed                ...$buildArgs       An optional set of build arguments that should be provided to the
-     *                                                  class constructor method.
+     * @param  mixed                ...$buildArgs       An optional set of build arguments that should be provided to
+     *                                                  the class constructor method.
      *
      * @throws NotFoundException If the class does not exist.
      */

--- a/src/Builders/ClassBuilder.php
+++ b/src/Builders/ClassBuilder.php
@@ -62,18 +62,18 @@ class ClassBuilder implements BuilderInterface, ReinitializableBuilderInterface
      */
     protected $isInterface = false;
 
-    /**
-     * ClassBuilder constructor.
-     *
-     * @param string             $id                The identifier associated with this builder.
-     * @param Resolver           $resolver          A reference to the resolver currently using the builder.
-     * @param string             $className         The fully-qualified class name to build instances for.
-     * @param array<string>|null $afterBuildMethods An optional set of methods to call on the built object.
-     * @param mixed              ...$buildArgs      An optional set of build arguments that should be provided to the
-     *                                              class constructor method.
-     *
-     * @throws NotFoundException If the class does not exist.
-     */
+	/**
+	 * ClassBuilder constructor.
+	 *
+	 * @param  string|class-string  $id                 The identifier associated with this builder.
+	 * @param  Resolver             $resolver           A reference to the resolver currently using the builder.
+	 * @param  string               $className          The fully-qualified class name to build instances for.
+	 * @param  string[]|null        $afterBuildMethods  An optional set of methods to call on the built object.
+	 * @param  mixed                ...$buildArgs       An optional set of build arguments that should be provided to the
+	 *                                                  class constructor method.
+	 *
+	 * @throws NotFoundException If the class does not exist.
+	 */
     public function __construct($id, Resolver $resolver, $className, array $afterBuildMethods = null, ...$buildArgs)
     {
         if (!class_exists($className)) {
@@ -142,14 +142,15 @@ class ClassBuilder implements BuilderInterface, ReinitializableBuilderInterface
         return $constructorArgs;
     }
 
-    /**
-     * Returns a set of resolved constructor parameters.
-     *
-     * @param string $className The fully-qualified class name to get the resolved constructor parameters yet.
-     * @return array<Parameter> A set of resolved constructor parameters.
-     *
-     * @throws ContainerException If the resolution of any constructor parameters is problematic.
-     */
+	/**
+	 * Returns a set of resolved constructor parameters.
+	 *
+	 * @param  class-string  $className  The fully-qualified class name to get the resolved constructor parameters yet.
+	 *
+	 * @return array<Parameter> A set of resolved constructor parameters.
+	 *
+	 * @throws ContainerException If the resolution of any constructor parameters is problematic.
+	 */
     protected function getResolvedConstructorParameters($className)
     {
         if (isset(self::$constructorParametersCache[$className])) {

--- a/src/Builders/ClassBuilder.php
+++ b/src/Builders/ClassBuilder.php
@@ -37,7 +37,7 @@ class ClassBuilder implements BuilderInterface, ReinitializableBuilderInterface
     /**
      * The fully-qualified class name the builder should build instances of.
      *
-     * @var string
+     * @var class-string
      */
     protected $className;
     /**

--- a/src/Builders/Factory.php
+++ b/src/Builders/Factory.php
@@ -42,21 +42,21 @@ class Factory
         $this->resolver = $resolver;
     }
 
-	/**
-	 * Returns the correct builder for a value.
-	 *
-	 * @param  string|class-string|mixed  $id                 The string id to provide a builder for, or a value.
-	 * @param  mixed                      $implementation     The implementation to build the builder for.
-	 * @param  string[]|null              $afterBuildMethods  A list of methods that should be called on the built instance
-	 *                                                        after
-	 *                                                        it's been built.
-	 * @param  mixed                      ...$buildArgs       A set of arguments to pass that should be used to build the
-	 *                                                        instance, if any.
-	 *
-	 * @return BuilderInterface A builder instance.
-	 *
-	 * @throws NotFoundException If a builder cannot find its implementation target.
-	 */
+    /**
+     * Returns the correct builder for a value.
+     *
+     * @param  string|class-string|mixed  $id                 The string id to provide a builder for, or a value.
+     * @param  mixed                      $implementation     The implementation to build the builder for.
+     * @param  string[]|null              $afterBuildMethods  A list of methods that should be called on the built instance
+     *                                                        after
+     *                                                        it's been built.
+     * @param  mixed                      ...$buildArgs       A set of arguments to pass that should be used to build the
+     *                                                        instance, if any.
+     *
+     * @return BuilderInterface A builder instance.
+     *
+     * @throws NotFoundException If a builder cannot find its implementation target.
+     */
     public function getBuilder($id, $implementation = null, array $afterBuildMethods = null, ...$buildArgs)
     {
         if ($implementation === null) {

--- a/src/Builders/Factory.php
+++ b/src/Builders/Factory.php
@@ -42,21 +42,21 @@ class Factory
         $this->resolver = $resolver;
     }
 
-    /**
-     * Returns the correct builder for a value.
-     *
-     * @param string|mixed       $id                 The string id to provide a builder for, or a value.
-     * @param mixed              $implementation     The implementation to build the builder for.
-     * @param array<string>|null $afterBuildMethods  A list of methods that should be called on the built instance
-     *                                               after
-     *                                               it's been built.
-     * @param mixed              ...$buildArgs       A set of arguments to pass that should be used to build the
-     *                                               instance, if any.
-     *
-     * @return BuilderInterface A builder instance.
-     *
-     * @throws NotFoundException If a builder cannot find its implementation target.
-     */
+	/**
+	 * Returns the correct builder for a value.
+	 *
+	 * @param  string|class-string|mixed  $id                 The string id to provide a builder for, or a value.
+	 * @param  mixed                      $implementation     The implementation to build the builder for.
+	 * @param  string[]|null              $afterBuildMethods  A list of methods that should be called on the built instance
+	 *                                                        after
+	 *                                                        it's been built.
+	 * @param  mixed                      ...$buildArgs       A set of arguments to pass that should be used to build the
+	 *                                                        instance, if any.
+	 *
+	 * @return BuilderInterface A builder instance.
+	 *
+	 * @throws NotFoundException If a builder cannot find its implementation target.
+	 */
     public function getBuilder($id, $implementation = null, array $afterBuildMethods = null, ...$buildArgs)
     {
         if ($implementation === null) {

--- a/src/Builders/Factory.php
+++ b/src/Builders/Factory.php
@@ -47,11 +47,10 @@ class Factory
      *
      * @param  string|class-string|mixed  $id                 The string id to provide a builder for, or a value.
      * @param  mixed                      $implementation     The implementation to build the builder for.
-     * @param  string[]|null              $afterBuildMethods  A list of methods that should be called on the built instance
-     *                                                        after
-     *                                                        it's been built.
-     * @param  mixed                      ...$buildArgs       A set of arguments to pass that should be used to build the
-     *                                                        instance, if any.
+     * @param  string[]|null              $afterBuildMethods  A list of methods that should be called on the built
+     *                                                        instance after it's been built.
+     * @param  mixed                      ...$buildArgs       A set of arguments to pass that should be used to build
+     *                                                        the instance, if any.
      *
      * @return BuilderInterface A builder instance.
      *

--- a/src/Builders/Parameter.php
+++ b/src/Builders/Parameter.php
@@ -206,7 +206,7 @@ class Parameter
         }
 
         try {
-            if (function_exists('enum_exists') && enum_exists($this->type)) {
+            if (function_exists('enum_exists') && enum_exists((string) $this->type)) {
                 return false;
             }
         } catch (ParseError $e) {

--- a/src/Builders/Resolver.php
+++ b/src/Builders/Resolver.php
@@ -193,6 +193,7 @@ class Resolver
      *                                                   use the current one.
      *
      * @return T|mixed The resolved value or instance.
+     * @phpstan-return ($id is class-string ? T : mixed)
      *
      * @throws NotFoundException If the id is a string that is not bound and is not an existing, concrete, class.
      */
@@ -294,7 +295,7 @@ class Resolver
      */
     public function addToBuildLine($type, $parameterName)
     {
-        $this->buildLine[] = trim("{$type} \${$parameterName}");
+        $this->buildLine[] = trim("$type \$$parameterName");
     }
 
     /**

--- a/src/Builders/Resolver.php
+++ b/src/Builders/Resolver.php
@@ -187,10 +187,10 @@ class Resolver
      *
      * @template T
      *
-     * @param  string|class-string<T>|mixed  $id         Either the id of a bound implementation, a class name or an object
-     *                                                   to resolve.
-     * @param  string[]|null                 $buildLine  The build line to append the resolution leafs to, or `null` to use the
-     *                                                   current one.
+     * @param  string|class-string<T>|mixed  $id         Either the id of a bound implementation, a class name or an
+     *                                                   object to resolve.
+     * @param  string[]|null                 $buildLine  The build line to append the resolution leafs to, or `null` to
+     *                                                   use the current one.
      *
      * @return T|mixed The resolved value or instance.
      *

--- a/src/Builders/Resolver.php
+++ b/src/Builders/Resolver.php
@@ -61,29 +61,29 @@ class Resolver
         $this->resolveUnboundAsSingletons = $resolveUnboundAsSingletons;
     }
 
-    /**
-     * Binds an implementation for an id, or class name, as prototype (build new each time).
-     *
-     * @param string           $id             The id to register the implementation for.
-     * @param BuilderInterface $implementation The builder that will provide the implementation for the id.
-     *
-     * @return void This method does not return any value.
-     */
+	/**
+	 * Binds an implementation for an id, or class name, as prototype (build new each time).
+	 *
+	 * @param  string|class-string  $id              The id to register the implementation for.
+	 * @param  BuilderInterface     $implementation  The builder that will provide the implementation for the id.
+	 *
+	 * @return void This method does not return any value.
+	 */
     public function bind($id, BuilderInterface $implementation)
     {
         unset($this->singletons[$id]);
         $this->bindings[$id] = $implementation;
     }
 
-    /**
-     * Registers an implementation for an id, or class name, as singleton (build at most once).
-     *
-     * @param string           $id             The id to register the implementation for.
-     * @param BuilderInterface $implementation The builder that will provide the implementation for
-     *                                         the id.
-     *
-     * @return void This method does not return any value.
-     */
+	/**
+	 * Registers an implementation for an id, or class name, as singleton (build at most once).
+	 *
+	 * @param  string|class-string  $id              The id to register the implementation for.
+	 * @param  BuilderInterface     $implementation  The builder that will provide the implementation for
+	 *                                               the id.
+	 *
+	 * @return void This method does not return any value.
+	 */
     public function singleton($id, BuilderInterface $implementation)
     {
         $this->singletons[$id] = true;
@@ -105,7 +105,7 @@ class Resolver
     /**
      * Removes the relation between an id and a bound implementation from the resolver.
      *
-     * @param string $id The id to unregister the implementation for.
+     * @param string|class-string $id The id to unregister the implementation for.
      *
      * @return void This method does not return any value.
      */
@@ -117,7 +117,7 @@ class Resolver
     /**
      * Returns whether a specific id is bound as singleton (build at most once), or not.
      *
-     * @param string $id The id to check.
+     * @param string|class-string $id The id to check.
      *
      * @return bool Whether a specific id is bound as singleton (build at most once), or not.
      */
@@ -126,15 +126,15 @@ class Resolver
         return isset($this->singletons[$id]);
     }
 
-    /**
-     * Transform the canonical class to the class part of a when-needs-give specification, if required.
-     *
-     * @param string $id         The ID to resolve the when-needs-give case for.
-     * @param string $paramClass The class of the parameter to solve the when-needs-give case for.
-     *
-     * @return BuilderInterface|string Either the builder for the when-needs-give replacement, or the input parameter
-     *                                 class if not found.
-     */
+	/**
+	 * Transform the canonical class to the class part of a when-needs-give specification, if required.
+	 *
+	 * @param  string|class-string  $id          The ID to resolve the when-needs-give case for.
+	 * @param  string               $paramClass  The class of the parameter to solve the when-needs-give case for.
+	 *
+	 * @return BuilderInterface|string Either the builder for the when-needs-give replacement, or the input parameter
+	 *                                 class if not found.
+	 */
     public function whenNeedsGive($id, $paramClass)
     {
         return isset($this->whenNeedsGive[$id][$paramClass]) ?
@@ -142,33 +142,34 @@ class Resolver
             : $paramClass;
     }
 
-    /**
-     * Sets an entry in the when->needs->give chain.
-     *
-     * @param string           $whenClass  The "when" part of the chain, a class name or id.
-     * @param string           $needsClass The "needs" part of the chain, a class name or id.
-     * @param BuilderInterface $builder    The Builder instance that should be returned when a class needs the
-     *                                     specified id.
-     *
-     * @return void This method does not return any value.
-     */
+	/**
+	 * Sets an entry in the when->needs->give chain.
+	 *
+	 * @param  string|class-string  $whenClass   The "when" part of the chain, a class name or id.
+	 * @param  string|class-string  $needsClass  The "needs" part of the chain, a class name or id.
+	 * @param  BuilderInterface     $builder     The Builder instance that should be returned when a class needs the
+	 *                                           specified id.
+	 *
+	 * @return void This method does not return any value.
+	 */
     public function setWhenNeedsGive($whenClass, $needsClass, BuilderInterface $builder)
     {
         $this->whenNeedsGive[$whenClass][$needsClass] = $builder;
     }
 
-    /**
-     * Resolves an ide to an implementation with the input arguments.
-     *
-     * @param string|mixed       $id                                  The id, class name or built value to resolve.
-     * @param array<string>|null $afterBuildMethods                   A list of methods that should run on the built
-     *                                                                instance.
-     * @param mixed              ...$buildArgs                        A set of build arguments that will be passed to
-     *                                                                the implementation constructor.
-     * @return BuilderInterface|ReinitializableBuilderInterface|mixed The builder, set up to use the specified set of
-     *                                                                build arguments.
-     * @throws NotFoundException If the id is a string that does not resolve to an existing, concrete, class.
-     */
+	/**
+	 * Resolves an ide to an implementation with the input arguments.
+	 *
+	 * @param  string|class-string|mixed  $id                         The id, class name or built value to resolve.
+	 * @param  string[]|null              $afterBuildMethods          A list of methods that should run on the built
+	 *                                                                instance.
+	 * @param  mixed                      ...$buildArgs               A set of build arguments that will be passed to
+	 *                                                                the implementation constructor.
+	 *
+	 * @return BuilderInterface|ReinitializableBuilderInterface|mixed The builder, set up to use the specified set of
+	 *                                                                build arguments.
+	 * @throws NotFoundException If the id is a string that does not resolve to an existing, concrete, class.
+	 */
     public function resolveWithArgs($id, array $afterBuildMethods = null, ...$buildArgs)
     {
         if (! is_string($id)) {
@@ -181,17 +182,20 @@ class Resolver
         return $this->cloneBuilder($id, $afterBuildMethods, ...$buildArgs)->build();
     }
 
-    /**
-     * Resolves an id or input value to a value or object instance.
-     *
-     * @param string|mixed       $id        Either the id of a bound implementation, a class name or an object
-     *                                      to resolve.
-     * @param array<string>|null $buildLine The build line to append the resolution leafs to, or `null` to use the
-     *                                      current one.
-     * @return mixed The resolved value or instance.
-     *
-     * @throws NotFoundException If the id is a string that is not bound and is not an existing, concrete, class.
-     */
+	/**
+	 * Resolves an id or input value to a value or object instance.
+	 *
+	 * @template T
+	 *
+	 * @param  string|class-string<T>|mixed  $id         Either the id of a bound implementation, a class name or an object
+	 *                                                   to resolve.
+	 * @param  string[]|null                 $buildLine  The build line to append the resolution leafs to, or `null` to use the
+	 *                                                   current one.
+	 *
+	 * @return T|mixed The resolved value or instance.
+	 *                 
+	 * @throws NotFoundException If the id is a string that is not bound and is not an existing, concrete, class.
+	 */
     public function resolve($id, array $buildLine = null)
     {
         if ($buildLine !== null) {
@@ -218,7 +222,7 @@ class Resolver
     /**
      * Builds, with auto-wiring, an instance of a not bound class.
      *
-     * @param string $id The class name to build an instance of.
+     * @param string|class-string $id The class name to build an instance of.
      *
      * @return object The built class instance.
      *
@@ -239,7 +243,7 @@ class Resolver
     /**
      * Resolves a bound implementation to a value or object.
      *
-     * @param string $id The id to resolve the implementation for.
+     * @param string|class-string $id The id to resolve the implementation for.
      *
      * @return mixed The resolved instance.
      */
@@ -253,20 +257,19 @@ class Resolver
         return $built;
     }
 
-    /**
-     * Clones the builder assigned to an id and re-initializes it.
-     *
-     * The clone operation leverages the already resolved dependencies of a builder to create an up-to-date instance.
-     *
-     * @param string             $id                The id to clone the builder of.
-     * @param array<string>|null $afterBuildMethods A set of methods to run on the built instance.
-     * @param mixed              ...$buildArgs      An optional set of arguments that will be passed to the instance
-     *                                              constructor.
-     * @return BuilderInterface A new instance of the builder currently related to the id.
-     *
-     * @throws NotFoundException If trying to clone the builder for a non existing id or an id that does not map to a
-     *                           concrete class name.
-     */
+	/**
+	 * Clones the builder assigned to an id and re-initializes it.
+	 * The clone operation leverages the already resolved dependencies of a builder to create an up-to-date instance.
+	 *
+	 * @param  string|class-string  $id                 The id to clone the builder of.
+	 * @param  string[]|null        $afterBuildMethods  A set of methods to run on the built instance.
+	 * @param  mixed                ...$buildArgs       An optional set of arguments that will be passed to the instance
+	 *                                                  constructor.
+	 *
+	 * @return BuilderInterface A new instance of the builder currently related to the id.
+	 * @throws NotFoundException If trying to clone the builder for a non existing id or an id that does not map to a
+	 *                           concrete class name.
+	 */
     private function cloneBuilder($id, array $afterBuildMethods = null, ...$buildArgs)
     {
         if (isset($this->bindings[$id]) && $this->bindings[$id] instanceof BuilderInterface) {
@@ -300,7 +303,7 @@ class Resolver
      * The build line will return a straight path from the current resolution root to the leaf
      * currently being resolved. Used for error logging and formatting.
      *
-     * @return array<string> A set of consecutive items the resolver is currently trying to build.
+     * @return string[] A set of consecutive items the resolver is currently trying to build.
      */
     public function getBuildLine()
     {

--- a/src/Builders/Resolver.php
+++ b/src/Builders/Resolver.php
@@ -61,29 +61,29 @@ class Resolver
         $this->resolveUnboundAsSingletons = $resolveUnboundAsSingletons;
     }
 
-	/**
-	 * Binds an implementation for an id, or class name, as prototype (build new each time).
-	 *
-	 * @param  string|class-string  $id              The id to register the implementation for.
-	 * @param  BuilderInterface     $implementation  The builder that will provide the implementation for the id.
-	 *
-	 * @return void This method does not return any value.
-	 */
+    /**
+     * Binds an implementation for an id, or class name, as prototype (build new each time).
+     *
+     * @param  string|class-string  $id              The id to register the implementation for.
+     * @param  BuilderInterface     $implementation  The builder that will provide the implementation for the id.
+     *
+     * @return void This method does not return any value.
+     */
     public function bind($id, BuilderInterface $implementation)
     {
         unset($this->singletons[$id]);
         $this->bindings[$id] = $implementation;
     }
 
-	/**
-	 * Registers an implementation for an id, or class name, as singleton (build at most once).
-	 *
-	 * @param  string|class-string  $id              The id to register the implementation for.
-	 * @param  BuilderInterface     $implementation  The builder that will provide the implementation for
-	 *                                               the id.
-	 *
-	 * @return void This method does not return any value.
-	 */
+    /**
+     * Registers an implementation for an id, or class name, as singleton (build at most once).
+     *
+     * @param  string|class-string  $id              The id to register the implementation for.
+     * @param  BuilderInterface     $implementation  The builder that will provide the implementation for
+     *                                               the id.
+     *
+     * @return void This method does not return any value.
+     */
     public function singleton($id, BuilderInterface $implementation)
     {
         $this->singletons[$id] = true;
@@ -126,15 +126,15 @@ class Resolver
         return isset($this->singletons[$id]);
     }
 
-	/**
-	 * Transform the canonical class to the class part of a when-needs-give specification, if required.
-	 *
-	 * @param  string|class-string  $id          The ID to resolve the when-needs-give case for.
-	 * @param  string               $paramClass  The class of the parameter to solve the when-needs-give case for.
-	 *
-	 * @return BuilderInterface|string Either the builder for the when-needs-give replacement, or the input parameter
-	 *                                 class if not found.
-	 */
+    /**
+     * Transform the canonical class to the class part of a when-needs-give specification, if required.
+     *
+     * @param  string|class-string  $id          The ID to resolve the when-needs-give case for.
+     * @param  string               $paramClass  The class of the parameter to solve the when-needs-give case for.
+     *
+     * @return BuilderInterface|string Either the builder for the when-needs-give replacement, or the input parameter
+     *                                 class if not found.
+     */
     public function whenNeedsGive($id, $paramClass)
     {
         return isset($this->whenNeedsGive[$id][$paramClass]) ?
@@ -142,34 +142,34 @@ class Resolver
             : $paramClass;
     }
 
-	/**
-	 * Sets an entry in the when->needs->give chain.
-	 *
-	 * @param  string|class-string  $whenClass   The "when" part of the chain, a class name or id.
-	 * @param  string|class-string  $needsClass  The "needs" part of the chain, a class name or id.
-	 * @param  BuilderInterface     $builder     The Builder instance that should be returned when a class needs the
-	 *                                           specified id.
-	 *
-	 * @return void This method does not return any value.
-	 */
+    /**
+     * Sets an entry in the when->needs->give chain.
+     *
+     * @param  string|class-string  $whenClass   The "when" part of the chain, a class name or id.
+     * @param  string|class-string  $needsClass  The "needs" part of the chain, a class name or id.
+     * @param  BuilderInterface     $builder     The Builder instance that should be returned when a class needs the
+     *                                           specified id.
+     *
+     * @return void This method does not return any value.
+     */
     public function setWhenNeedsGive($whenClass, $needsClass, BuilderInterface $builder)
     {
         $this->whenNeedsGive[$whenClass][$needsClass] = $builder;
     }
 
-	/**
-	 * Resolves an ide to an implementation with the input arguments.
-	 *
-	 * @param  string|class-string|mixed  $id                         The id, class name or built value to resolve.
-	 * @param  string[]|null              $afterBuildMethods          A list of methods that should run on the built
-	 *                                                                instance.
-	 * @param  mixed                      ...$buildArgs               A set of build arguments that will be passed to
-	 *                                                                the implementation constructor.
-	 *
-	 * @return BuilderInterface|ReinitializableBuilderInterface|mixed The builder, set up to use the specified set of
-	 *                                                                build arguments.
-	 * @throws NotFoundException If the id is a string that does not resolve to an existing, concrete, class.
-	 */
+    /**
+     * Resolves an ide to an implementation with the input arguments.
+     *
+     * @param  string|class-string|mixed  $id                         The id, class name or built value to resolve.
+     * @param  string[]|null              $afterBuildMethods          A list of methods that should run on the built
+     *                                                                instance.
+     * @param  mixed                      ...$buildArgs               A set of build arguments that will be passed to
+     *                                                                the implementation constructor.
+     *
+     * @return BuilderInterface|ReinitializableBuilderInterface|mixed The builder, set up to use the specified set of
+     *                                                                build arguments.
+     * @throws NotFoundException If the id is a string that does not resolve to an existing, concrete, class.
+     */
     public function resolveWithArgs($id, array $afterBuildMethods = null, ...$buildArgs)
     {
         if (! is_string($id)) {
@@ -182,20 +182,20 @@ class Resolver
         return $this->cloneBuilder($id, $afterBuildMethods, ...$buildArgs)->build();
     }
 
-	/**
-	 * Resolves an id or input value to a value or object instance.
-	 *
-	 * @template T
-	 *
-	 * @param  string|class-string<T>|mixed  $id         Either the id of a bound implementation, a class name or an object
-	 *                                                   to resolve.
-	 * @param  string[]|null                 $buildLine  The build line to append the resolution leafs to, or `null` to use the
-	 *                                                   current one.
-	 *
-	 * @return T|mixed The resolved value or instance.
-	 *                 
-	 * @throws NotFoundException If the id is a string that is not bound and is not an existing, concrete, class.
-	 */
+    /**
+     * Resolves an id or input value to a value or object instance.
+     *
+     * @template T
+     *
+     * @param  string|class-string<T>|mixed  $id         Either the id of a bound implementation, a class name or an object
+     *                                                   to resolve.
+     * @param  string[]|null                 $buildLine  The build line to append the resolution leafs to, or `null` to use the
+     *                                                   current one.
+     *
+     * @return T|mixed The resolved value or instance.
+     *
+     * @throws NotFoundException If the id is a string that is not bound and is not an existing, concrete, class.
+     */
     public function resolve($id, array $buildLine = null)
     {
         if ($buildLine !== null) {
@@ -257,19 +257,19 @@ class Resolver
         return $built;
     }
 
-	/**
-	 * Clones the builder assigned to an id and re-initializes it.
-	 * The clone operation leverages the already resolved dependencies of a builder to create an up-to-date instance.
-	 *
-	 * @param  string|class-string  $id                 The id to clone the builder of.
-	 * @param  string[]|null        $afterBuildMethods  A set of methods to run on the built instance.
-	 * @param  mixed                ...$buildArgs       An optional set of arguments that will be passed to the instance
-	 *                                                  constructor.
-	 *
-	 * @return BuilderInterface A new instance of the builder currently related to the id.
-	 * @throws NotFoundException If trying to clone the builder for a non existing id or an id that does not map to a
-	 *                           concrete class name.
-	 */
+    /**
+     * Clones the builder assigned to an id and re-initializes it.
+     * The clone operation leverages the already resolved dependencies of a builder to create an up-to-date instance.
+     *
+     * @param  string|class-string  $id                 The id to clone the builder of.
+     * @param  string[]|null        $afterBuildMethods  A set of methods to run on the built instance.
+     * @param  mixed                ...$buildArgs       An optional set of arguments that will be passed to the instance
+     *                                                  constructor.
+     *
+     * @return BuilderInterface A new instance of the builder currently related to the id.
+     * @throws NotFoundException If trying to clone the builder for a non existing id or an id that does not map to a
+     *                           concrete class name.
+     */
     private function cloneBuilder($id, array $afterBuildMethods = null, ...$buildArgs)
     {
         if (isset($this->bindings[$id]) && $this->bindings[$id] instanceof BuilderInterface) {

--- a/src/Container.php
+++ b/src/Container.php
@@ -47,7 +47,7 @@ class Container implements ArrayAccess, ContainerInterface
     /**
      * A list of bound and resolved singletons.
      *
-     * @var array<string,bool>
+     * @var array<string|class-string,bool>
      */
     protected $singletons = [];
     /**
@@ -182,11 +182,11 @@ class Container implements ArrayAccess, ContainerInterface
     /**
      * Finds an entry of the container by its identifier and returns it.
      *
-     * @param string $offset Identifier of the entry to look for.
+     * @template T
      *
-     * @return mixed The entry for an id.
+     * @param string|class-string<T> $offset Identifier of the entry to look for.
      *
-     * @return mixed The value for the offset.
+     * @return T|mixed The value for the offset.
      *
      * @throws ContainerException Error while retrieving the entry.
      * @throws NotFoundException  No entry was found for **this** identifier.
@@ -197,15 +197,17 @@ class Container implements ArrayAccess, ContainerInterface
         return $this->get($offset);
     }
 
-    /**
-     * Finds an entry of the container by its identifier and returns it.
-     *
-     * @param string $id A fully qualified class or interface name or an already built object.
-     *
-     * @return mixed The entry for an id.
-     *
-     * @throws ContainerException Error while retrieving the entry.
-     */
+	/**
+	 * Finds an entry of the container by its identifier and returns it.
+	 *
+	 * @template T
+	 *
+	 * @param  string|class-string<T>  $id  A fully qualified class or interface name or an already built object.
+	 *
+	 * @return T|mixed The entry for an id.
+	 *
+	 * @throws ContainerException Error while retrieving the entry.
+	 */
     public function get($id)
     {
         try {
@@ -248,9 +250,12 @@ class Container implements ArrayAccess, ContainerInterface
      * If the implementation has been bound as singleton using the `singleton` method
      * or the ArrayAccess API then the implementation will be resolved just on the first request.
      *
-     * @param string $id A fully qualified class or interface name or an already built object.
+     * @template T
      *
-     * @return mixed
+     * @param string|class-string<T> $id A fully qualified class or interface name or an already built object.
+     *
+     * @return T|mixed
+     *
      * @throws ContainerException If the target of the make is not bound and is not a valid,
      *                                              concrete, class name or there's any issue making the target.
      */
@@ -266,7 +271,7 @@ class Container implements ArrayAccess, ContainerInterface
      * `$container[$id]` returning true does not mean that `$container[$id]` will not throw an exception.
      * It does however mean that `$container[$id]` will not throw a `NotFoundExceptionInterface`.
      *
-     * @param string $offset An offset to check for.
+     * @param string|class-string $offset An offset to check for.
      *
      * @return boolean true on success or false on failure.
      */
@@ -283,7 +288,7 @@ class Container implements ArrayAccess, ContainerInterface
      * `has($id)` returning true does not mean that `get($id)` will not throw an exception.
      * It does however mean that `get($id)` will not throw a `NotFoundExceptionInterface`.
      *
-     * @param string $id Identifier of the entry to look for.
+     * @param string|class-string $id Identifier of the entry to look for.
      *
      * @return bool Whether the container contains a binding for an id or not.
      */
@@ -363,7 +368,7 @@ class Container implements ArrayAccess, ContainerInterface
     /**
      * A wrapper around the `class_exists` function to capture and handle possible fatal errors on PHP 7.0+.
      *
-     * @param string $class The class name to check.
+     * @param string|class-string $class The class name to check.
      *
      * @return bool Whether the class exists or not.
      *
@@ -397,7 +402,7 @@ class Container implements ArrayAccess, ContainerInterface
     /**
      * Checks a class, interface or trait exists.
      *
-     * @param string $class The class, interface or trait to check.
+     * @param string|class-string $class The class, interface or trait to check.
      *
      * @return bool Whether the class, interface or trait exists or not.
      * @throws ReflectionException If the class should be checked for concreteness and it does not exist.
@@ -432,7 +437,7 @@ class Container implements ArrayAccess, ContainerInterface
      * If a provider overloads the `boot` method that method will be called when the `boot` method is called on the
      * container itself.
      *
-     * @param string $serviceProviderClass The fully-qualified Service Provider class name.
+     * @param class-string $serviceProviderClass The fully-qualified Service Provider class name.
      * @param string ...$alias             A list of aliases the provider should be registered with.
      * @return void This method does not return any value.
      * @throws ContainerException If the Service Provider is not correctly configured or there's an issue
@@ -503,20 +508,21 @@ class Container implements ArrayAccess, ContainerInterface
         };
     }
 
-    /**
-     * Binds an interface, a class or a string slug to an implementation.
-     *
-     * Existing implementations are replaced.
-     *
-     * @param string             $id                A class or interface fully qualified name or a string slug.
-     * @param mixed              $implementation    The implementation that should be bound to the alias(es); can be a
-     *                                              class name, an object or a closure.
-     * @param array<string>|null $afterBuildMethods An array of methods that should be called on the built
-     *                                              implementation after resolving it.
-     *
-     * @return void The method does not return any value.
-     * @throws ContainerException      If there's an issue while trying to bind the implementation.
-     */
+	/**
+	 * Binds an interface, a class or a string slug to an implementation.
+	 *
+	 * Existing implementations are replaced.
+	 *
+	 * @param  string|class-string  $id                 A class or interface fully qualified name or a string slug.
+	 * @param  mixed                $implementation     The implementation that should be bound to the alias(es); can be a
+	 *                                                  class name, an object or a closure.
+	 * @param  string[]|null        $afterBuildMethods  An array of methods that should be called on the built
+	 *                                                  implementation after resolving it.
+	 *
+	 * @return void The method does not return any value.
+	 *
+	 * @throws ContainerException      If there's an issue while trying to bind the implementation.
+	 */
     public function bind($id, $implementation = null, array $afterBuildMethods = null)
     {
         if ($implementation === null) {
@@ -548,22 +554,21 @@ class Container implements ArrayAccess, ContainerInterface
         }
     }
 
-    /**
-     * Binds a class, interface or string slug to a chain of implementations decorating a base
-     * object; the chain will be lazily resolved only on the first call.
-     *
-     * The base decorated object must be the last element of the array.
-     *
-     * @param string                        $id                The class, interface or slug the decorator chain should
-     *                                                         be bound to.
-     * @param array<string|object|callable> $decorators        An array of implementations that decorate an object.
-     * @param array<string>|null            $afterBuildMethods An array of methods that should be called on the
-     *                                                         instance after it has been built; the methods should not
-     *                                                         require any argument.
-     *
-     * @return void This method does not return any value.
-     * @throws ContainerException
-     */
+	/**
+	 * Binds a class, interface or string slug to a chain of implementations decorating a base
+	 * object; the chain will be lazily resolved only on the first call.
+	 * The base decorated object must be the last element of the array.
+	 *
+	 * @param  string|class-string            $id                 The class, interface or slug the decorator chain should
+	 *                                                            be bound to.
+	 * @param  array<string|object|callable>  $decorators         An array of implementations that decorate an object.
+	 * @param  string[]|null                  $afterBuildMethods  An array of methods that should be called on the
+	 *                                                            instance after it has been built; the methods should not
+	 *                                                            require any argument.
+	 *
+	 * @return void This method does not return any value.
+	 * @throws ContainerException
+	 */
     public function singletonDecorators($id, $decorators, array $afterBuildMethods = null)
     {
         $this->resolver->singleton($id, $this->getDecoratorBuilder($decorators, $id, $afterBuildMethods));
@@ -598,22 +603,22 @@ class Container implements ArrayAccess, ContainerInterface
         return $builder;
     }
 
-    /**
-     * Binds a class, interface or string slug to to a chain of implementations decorating a
-     * base object.
-     *
-     * The base decorated object must be the last element of the array.
-     *
-     * @param string                        $id                The class, interface or slug the decorator chain should
-     *                                                         be bound to.
-     * @param array<string|object|callable> $decorators        An array of implementations that decorate an object.
-     * @param array<string>|null            $afterBuildMethods An array of methods that should be called on the
-     *                                                         instance after it has been built; the methods should not
-     *                                                         require any argument.
-     *
-     * @return void This method does not return any value.
-     * @throws ContainerException If there's any issue binding the decorators.
-     */
+	/**
+	 * Binds a class, interface or string slug to a chain of implementations decorating a
+	 * base object.
+	 *
+	 * The base decorated object must be the last element of the array.
+	 *
+	 * @param  string|class-string            $id                 The class, interface or slug the decorator chain should
+	 *                                                            be bound to.
+	 * @param  array<string|object|callable>  $decorators         An array of implementations that decorate an object.
+	 * @param  string[]|null                  $afterBuildMethods  An array of methods that should be called on the
+	 *                                                            instance after it has been built; the methods should not
+	 *                                                            require any argument.
+	 *
+	 * @return void This method does not return any value.
+	 * @throws ContainerException If there's any issue binding the decorators.
+	 */
     public function bindDecorators($id, array $decorators, array $afterBuildMethods = null)
     {
         $this->resolver->bind($id, $this->getDecoratorBuilder($decorators, $id, $afterBuildMethods));
@@ -639,7 +644,7 @@ class Container implements ArrayAccess, ContainerInterface
     /**
      * Starts the `when->needs->give` chain for a contextual binding.
      *
-     * @param string $class The fully qualified name of the requesting class.
+     * @param string|class-string $class The fully qualified name of the requesting class.
      *
      * Example:
      *
@@ -647,8 +652,8 @@ class Container implements ArrayAccess, ContainerInterface
      *      $container->singleton('LoggerInterface', 'FilesystemLogger');
      *      // But if the requesting class is `Worker` return another implementation
      *      $container->when('Worker')
-     *          ->needs('LoggerInterface)
-     *          ->give('RemoteLogger);
+     *          ->needs('LoggerInterface')
+     *          ->give('RemoteLogger');
      *
      * @return Container The container instance, to continue the when/needs/give chain.
      */
@@ -668,10 +673,10 @@ class Container implements ArrayAccess, ContainerInterface
      *      $container->singleton('LoggerInterface', 'FilesystemLogger');
      *      // But if the requesting class is `Worker` return another implementation.
      *      $container->when('Worker')
-     *          ->needs('LoggerInterface)
-     *          ->give('RemoteLogger);
+     *          ->needs('LoggerInterface')
+     *          ->give('RemoteLogger');
      *
-     * @param string $id The class or interface needed by the class.
+     * @param string|class-string $id The class or interface needed by the class.
      *
      * @return Container The container instance, to continue the when/needs/give chain.
      */
@@ -691,8 +696,8 @@ class Container implements ArrayAccess, ContainerInterface
      *      $container->singleton('LoggerInterface', 'FilesystemLogger');
      *      // but if the requesting class is `Worker` return another implementation
      *      $container->when('Worker')
-     *          ->needs('LoggerInterface)
-     *          ->give('RemoteLogger);
+     *          ->needs('LoggerInterface')
+     *          ->give('RemoteLogger');
      *
      * @param mixed $implementation The implementation specified
      *
@@ -707,19 +712,18 @@ class Container implements ArrayAccess, ContainerInterface
         unset($this->whenClass, $this->needsClass);
     }
 
-    /**
-     * Returns a lambda function suitable to use as a callback; when called the function will build the implementation
-     * bound to `$id` and return the value of a call to `$method` method with the call arguments.
-     *
-     * @param string|object $id               A fully-qualified class name, a bound slug or an object o call the
-     *                                        callback on.
-     * @param string        $method           The method that should be called on the resolved implementation with the
-     *                                        specified array arguments.
-     *
-     * @return callable The callback function.
-     *
-     * @throws ContainerException If the id is not a bound implementation or valid class name.
-     */
+	/**
+	 * Returns a lambda function suitable to use as a callback; when called the function will build the implementation
+	 * bound to `$id` and return the value of a call to `$method` method with the call arguments.
+	 *
+	 * @param  string|class-string|object  $id      A fully-qualified class name, a bound slug or an object o call the
+	 *                                              callback on.
+	 * @param  string                      $method  The method that should be called on the resolved implementation with the
+	 *                                              specified array arguments.
+	 *
+	 * @return callable|Closure The callback function.
+	 * @throws ContainerException If the id is not a bound implementation or valid class name.
+	 */
     public function callback($id, $method)
     {
         $callbackIdPrefix = is_object($id) ? spl_object_hash($id) : $id;
@@ -756,14 +760,14 @@ class Container implements ArrayAccess, ContainerInterface
         return $callbackClosure;
     }
 
-    /**
-     * Whether a method of an id, possibly not a class, is static or not.
-     *
-     * @param object|string $object A class name, instance or something that does not map to a class.
-     * @param string        $method The method to check.
-     *
-     * @return bool Whether a method of an id or class is static or not.
-     */
+	/**
+	 * Whether a method of an id, possibly not a class, is static or not.
+	 *
+	 * @param  object|string|class-string  $object  A class name, instance or something that does not map to a class.
+	 * @param  string                      $method  The method to check.
+	 *
+	 * @return bool Whether a method of an id or class is static or not.
+	 */
     protected function isStaticMethod($object, $method)
     {
         $key = is_string($object) ? $object . '::' . $method : get_class($object) . '::' . $method;
@@ -782,17 +786,16 @@ class Container implements ArrayAccess, ContainerInterface
     /**
      * Returns a callable object that will build an instance of the specified class using the
      * specified arguments when called.
-     *
      * The callable will be a closure on PHP 5.3+ or a lambda function on PHP 5.2.
      *
-     * @param string|mixed       $id                The fully qualified name of a class or an interface.
-     * @param array<mixed>       $buildArgs         An array of arguments that should be used to build the instance;
-     *                                              note that any argument will be resolved using the container itself
-     *                                              and bindings will apply.
-     * @param array<string>|null $afterBuildMethods An array of methods that should be called on the built
-     *                                              implementation after resolving it.
+     * @param  string|class-string|mixed  $id                 The fully qualified name of a class or an interface.
+     * @param  array<mixed>               $buildArgs          An array of arguments that should be used to build the instance;
+     *                                                        note that any argument will be resolved using the container itself
+     *                                                        and bindings will apply.
+     * @param  string[]|null              $afterBuildMethods  An array of methods that should be called on the built
+     *                                                        implementation after resolving it.
      *
-     * @return callable  A callable function that will return an instance of the specified class when
+     * @return callable|Closure  A callable function that will return an instance of the specified class when
      *                   called.
      */
     public function instance($id, array $buildArgs = [], array $afterBuildMethods = null)
@@ -821,7 +824,7 @@ class Container implements ArrayAccess, ContainerInterface
     /**
      * Returns the Service Provider instance registered.
      *
-     * @param string $providerId The Service Provider clas to return the instance for.
+     * @param string|class-string $providerId The Service Provider clas to return the instance for.
      *
      * @return ServiceProvider The service provider instance.
      *
@@ -831,13 +834,13 @@ class Container implements ArrayAccess, ContainerInterface
     public function getProvider($providerId)
     {
         if (!$this->resolver->isBound($providerId)) {
-            throw new NotFoundException("Service provider '{$providerId}' is not registered in the container.");
+            throw new NotFoundException("Service provider '$providerId' is not registered in the container.");
         }
 
         $provider = $this->get($providerId);
 
         if (! $provider instanceof ServiceProvider) {
-            throw new NotFoundException("Bound implementation for '{$providerId}' is not Service Provider.");
+            throw new NotFoundException("Bound implementation for '$providerId' is not Service Provider.");
         }
 
         return $provider;

--- a/src/Container.php
+++ b/src/Container.php
@@ -197,17 +197,17 @@ class Container implements ArrayAccess, ContainerInterface
         return $this->get($offset);
     }
 
-	/**
-	 * Finds an entry of the container by its identifier and returns it.
-	 *
-	 * @template T
-	 *
-	 * @param  string|class-string<T>  $id  A fully qualified class or interface name or an already built object.
-	 *
-	 * @return T|mixed The entry for an id.
-	 *
-	 * @throws ContainerException Error while retrieving the entry.
-	 */
+    /**
+     * Finds an entry of the container by its identifier and returns it.
+     *
+     * @template T
+     *
+     * @param  string|class-string<T>  $id  A fully qualified class or interface name or an already built object.
+     *
+     * @return T|mixed The entry for an id.
+     *
+     * @throws ContainerException Error while retrieving the entry.
+     */
     public function get($id)
     {
         try {
@@ -508,21 +508,21 @@ class Container implements ArrayAccess, ContainerInterface
         };
     }
 
-	/**
-	 * Binds an interface, a class or a string slug to an implementation.
-	 *
-	 * Existing implementations are replaced.
-	 *
-	 * @param  string|class-string  $id                 A class or interface fully qualified name or a string slug.
-	 * @param  mixed                $implementation     The implementation that should be bound to the alias(es); can be a
-	 *                                                  class name, an object or a closure.
-	 * @param  string[]|null        $afterBuildMethods  An array of methods that should be called on the built
-	 *                                                  implementation after resolving it.
-	 *
-	 * @return void The method does not return any value.
-	 *
-	 * @throws ContainerException      If there's an issue while trying to bind the implementation.
-	 */
+    /**
+     * Binds an interface, a class or a string slug to an implementation.
+     *
+     * Existing implementations are replaced.
+     *
+     * @param  string|class-string  $id                 A class or interface fully qualified name or a string slug.
+     * @param  mixed                $implementation     The implementation that should be bound to the alias(es); can be a
+     *                                                  class name, an object or a closure.
+     * @param  string[]|null        $afterBuildMethods  An array of methods that should be called on the built
+     *                                                  implementation after resolving it.
+     *
+     * @return void The method does not return any value.
+     *
+     * @throws ContainerException      If there's an issue while trying to bind the implementation.
+     */
     public function bind($id, $implementation = null, array $afterBuildMethods = null)
     {
         if ($implementation === null) {
@@ -554,21 +554,21 @@ class Container implements ArrayAccess, ContainerInterface
         }
     }
 
-	/**
-	 * Binds a class, interface or string slug to a chain of implementations decorating a base
-	 * object; the chain will be lazily resolved only on the first call.
-	 * The base decorated object must be the last element of the array.
-	 *
-	 * @param  string|class-string            $id                 The class, interface or slug the decorator chain should
-	 *                                                            be bound to.
-	 * @param  array<string|object|callable>  $decorators         An array of implementations that decorate an object.
-	 * @param  string[]|null                  $afterBuildMethods  An array of methods that should be called on the
-	 *                                                            instance after it has been built; the methods should not
-	 *                                                            require any argument.
-	 *
-	 * @return void This method does not return any value.
-	 * @throws ContainerException
-	 */
+    /**
+     * Binds a class, interface or string slug to a chain of implementations decorating a base
+     * object; the chain will be lazily resolved only on the first call.
+     * The base decorated object must be the last element of the array.
+     *
+     * @param  string|class-string            $id                 The class, interface or slug the decorator chain should
+     *                                                            be bound to.
+     * @param  array<string|object|callable>  $decorators         An array of implementations that decorate an object.
+     * @param  string[]|null                  $afterBuildMethods  An array of methods that should be called on the
+     *                                                            instance after it has been built; the methods should not
+     *                                                            require any argument.
+     *
+     * @return void This method does not return any value.
+     * @throws ContainerException
+     */
     public function singletonDecorators($id, $decorators, array $afterBuildMethods = null)
     {
         $this->resolver->singleton($id, $this->getDecoratorBuilder($decorators, $id, $afterBuildMethods));
@@ -603,22 +603,22 @@ class Container implements ArrayAccess, ContainerInterface
         return $builder;
     }
 
-	/**
-	 * Binds a class, interface or string slug to a chain of implementations decorating a
-	 * base object.
-	 *
-	 * The base decorated object must be the last element of the array.
-	 *
-	 * @param  string|class-string            $id                 The class, interface or slug the decorator chain should
-	 *                                                            be bound to.
-	 * @param  array<string|object|callable>  $decorators         An array of implementations that decorate an object.
-	 * @param  string[]|null                  $afterBuildMethods  An array of methods that should be called on the
-	 *                                                            instance after it has been built; the methods should not
-	 *                                                            require any argument.
-	 *
-	 * @return void This method does not return any value.
-	 * @throws ContainerException If there's any issue binding the decorators.
-	 */
+    /**
+     * Binds a class, interface or string slug to a chain of implementations decorating a
+     * base object.
+     *
+     * The base decorated object must be the last element of the array.
+     *
+     * @param  string|class-string            $id                 The class, interface or slug the decorator chain should
+     *                                                            be bound to.
+     * @param  array<string|object|callable>  $decorators         An array of implementations that decorate an object.
+     * @param  string[]|null                  $afterBuildMethods  An array of methods that should be called on the
+     *                                                            instance after it has been built; the methods should not
+     *                                                            require any argument.
+     *
+     * @return void This method does not return any value.
+     * @throws ContainerException If there's any issue binding the decorators.
+     */
     public function bindDecorators($id, array $decorators, array $afterBuildMethods = null)
     {
         $this->resolver->bind($id, $this->getDecoratorBuilder($decorators, $id, $afterBuildMethods));
@@ -712,18 +712,18 @@ class Container implements ArrayAccess, ContainerInterface
         unset($this->whenClass, $this->needsClass);
     }
 
-	/**
-	 * Returns a lambda function suitable to use as a callback; when called the function will build the implementation
-	 * bound to `$id` and return the value of a call to `$method` method with the call arguments.
-	 *
-	 * @param  string|class-string|object  $id      A fully-qualified class name, a bound slug or an object o call the
-	 *                                              callback on.
-	 * @param  string                      $method  The method that should be called on the resolved implementation with the
-	 *                                              specified array arguments.
-	 *
-	 * @return callable|Closure The callback function.
-	 * @throws ContainerException If the id is not a bound implementation or valid class name.
-	 */
+    /**
+     * Returns a lambda function suitable to use as a callback; when called the function will build the implementation
+     * bound to `$id` and return the value of a call to `$method` method with the call arguments.
+     *
+     * @param  string|class-string|object  $id      A fully-qualified class name, a bound slug or an object o call the
+     *                                              callback on.
+     * @param  string                      $method  The method that should be called on the resolved implementation with the
+     *                                              specified array arguments.
+     *
+     * @return callable|Closure The callback function.
+     * @throws ContainerException If the id is not a bound implementation or valid class name.
+     */
     public function callback($id, $method)
     {
         $callbackIdPrefix = is_object($id) ? spl_object_hash($id) : $id;
@@ -760,14 +760,14 @@ class Container implements ArrayAccess, ContainerInterface
         return $callbackClosure;
     }
 
-	/**
-	 * Whether a method of an id, possibly not a class, is static or not.
-	 *
-	 * @param  object|string|class-string  $object  A class name, instance or something that does not map to a class.
-	 * @param  string                      $method  The method to check.
-	 *
-	 * @return bool Whether a method of an id or class is static or not.
-	 */
+    /**
+     * Whether a method of an id, possibly not a class, is static or not.
+     *
+     * @param  object|string|class-string  $object  A class name, instance or something that does not map to a class.
+     * @param  string                      $method  The method to check.
+     *
+     * @return bool Whether a method of an id or class is static or not.
+     */
     protected function isStaticMethod($object, $method)
     {
         $key = is_string($object) ? $object . '::' . $method : get_class($object) . '::' . $method;

--- a/src/Container.php
+++ b/src/Container.php
@@ -514,8 +514,8 @@ class Container implements ArrayAccess, ContainerInterface
      * Existing implementations are replaced.
      *
      * @param  string|class-string  $id                 A class or interface fully qualified name or a string slug.
-     * @param  mixed                $implementation     The implementation that should be bound to the alias(es); can be a
-     *                                                  class name, an object or a closure.
+     * @param  mixed                $implementation     The implementation that should be bound to the alias(es); can
+     *                                                  be a class name, an object or a closure.
      * @param  string[]|null        $afterBuildMethods  An array of methods that should be called on the built
      *                                                  implementation after resolving it.
      *
@@ -559,12 +559,12 @@ class Container implements ArrayAccess, ContainerInterface
      * object; the chain will be lazily resolved only on the first call.
      * The base decorated object must be the last element of the array.
      *
-     * @param  string|class-string            $id                 The class, interface or slug the decorator chain should
-     *                                                            be bound to.
+     * @param  string|class-string            $id                 The class, interface or slug the decorator chain
+     *                                                            should be bound to.
      * @param  array<string|object|callable>  $decorators         An array of implementations that decorate an object.
      * @param  string[]|null                  $afterBuildMethods  An array of methods that should be called on the
-     *                                                            instance after it has been built; the methods should not
-     *                                                            require any argument.
+     *                                                            instance after it has been built; the methods should
+     *                                                            not require any argument.
      *
      * @return void This method does not return any value.
      * @throws ContainerException
@@ -609,12 +609,12 @@ class Container implements ArrayAccess, ContainerInterface
      *
      * The base decorated object must be the last element of the array.
      *
-     * @param  string|class-string            $id                 The class, interface or slug the decorator chain should
-     *                                                            be bound to.
+     * @param  string|class-string            $id                 The class, interface or slug the decorator chain
+     *                                                            should be bound to.
      * @param  array<string|object|callable>  $decorators         An array of implementations that decorate an object.
      * @param  string[]|null                  $afterBuildMethods  An array of methods that should be called on the
-     *                                                            instance after it has been built; the methods should not
-     *                                                            require any argument.
+     *                                                            instance after it has been built; the methods should
+     *                                                            not require any argument.
      *
      * @return void This method does not return any value.
      * @throws ContainerException If there's any issue binding the decorators.
@@ -718,8 +718,8 @@ class Container implements ArrayAccess, ContainerInterface
      *
      * @param  string|class-string|object  $id      A fully-qualified class name, a bound slug or an object o call the
      *                                              callback on.
-     * @param  string                      $method  The method that should be called on the resolved implementation with the
-     *                                              specified array arguments.
+     * @param  string                      $method  The method that should be called on the resolved implementation
+     *                                              with the specified array arguments.
      *
      * @return callable|Closure The callback function.
      * @throws ContainerException If the id is not a bound implementation or valid class name.
@@ -789,9 +789,9 @@ class Container implements ArrayAccess, ContainerInterface
      * The callable will be a closure on PHP 5.3+ or a lambda function on PHP 5.2.
      *
      * @param  string|class-string|mixed  $id                 The fully qualified name of a class or an interface.
-     * @param  array<mixed>               $buildArgs          An array of arguments that should be used to build the instance;
-     *                                                        note that any argument will be resolved using the container itself
-     *                                                        and bindings will apply.
+     * @param  array<mixed>               $buildArgs          An array of arguments that should be used to build the
+     *                                                        instance; note that any argument will be resolved using
+     *                                                        the container itself and bindings will apply.
      * @param  string[]|null              $afterBuildMethods  An array of methods that should be called on the built
      *                                                        implementation after resolving it.
      *

--- a/src/Container.php
+++ b/src/Container.php
@@ -187,6 +187,7 @@ class Container implements ArrayAccess, ContainerInterface
      * @param string|class-string<T> $offset Identifier of the entry to look for.
      *
      * @return T|mixed The value for the offset.
+     * @phpstan-return ($offset is class-string ? T : mixed)
      *
      * @throws ContainerException Error while retrieving the entry.
      * @throws NotFoundException  No entry was found for **this** identifier.
@@ -205,6 +206,7 @@ class Container implements ArrayAccess, ContainerInterface
      * @param  string|class-string<T>  $id  A fully qualified class or interface name or an already built object.
      *
      * @return T|mixed The entry for an id.
+     * @phpstan-return ($id is class-string ? T : mixed)
      *
      * @throws ContainerException Error while retrieving the entry.
      */
@@ -255,6 +257,7 @@ class Container implements ArrayAccess, ContainerInterface
      * @param string|class-string<T> $id A fully qualified class or interface name or an already built object.
      *
      * @return T|mixed
+     * @phpstan-return ($id is class-string ? T : mixed)
      *
      * @throws ContainerException If the target of the make is not bound and is not a valid,
      *                                              concrete, class name or there's any issue making the target.


### PR DESCRIPTION
Adds [PHPStan generics](https://phpstan.org/blog/generics-in-php-using-phpdocs) to multiple classes. IDEs that support them will get autocompletion (`.phpstorm.meta.php` not required) if a fully-qualified class name is used, e.g. `$instance = $container->get( Test::class );`.

PHPStorm with `.phpstorm.meta.php` deleted:
![image](https://github.com/lucatume/di52/assets/1066195/c80101de-e3ba-4b8b-b83c-bfd2e5e81f0a)
