### PR TITLE
Fix psr/container version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
   },
   "require": {
     "php": ">=7.1",
-    "psr/container": "^1.0",
+    "psr/container": "^1.0 <1.1.0",
     "ext-json": "*"
   },
   "require-dev": {


### PR DESCRIPTION
The compatibility of the library with PHP 7.1 implies that the version
of the PSR container from `1.1.0` and above is not possible.
